### PR TITLE
Home UI - My Groups

### DIFF
--- a/issuer/frontend/src/lib/components/GroupItem.svelte
+++ b/issuer/frontend/src/lib/components/GroupItem.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import AvatarSize from '$lib/ui-components/elements/AvatarSize.svelte';
+	import Badge from '$lib/ui-components/elements/Badge.svelte';
+	import Button from '$lib/ui-components/elements/Button.svelte';
+	import ListItem from '$lib/ui-components/elements/ListItem.svelte';
+	import type { MembershipStatus, PublicGroupData } from '../../declarations/meta_issuer.did';
+
+	export let group: PublicGroupData;
+
+	let isNotMember: boolean;
+	$: isNotMember = group.membership_status.length === 0 || 'Rejected' in group.membership_status[0];
+
+	const statusVariant = (status: MembershipStatus | undefined): 'success' | 'default' => {
+		if (status === undefined || 'Rejected' in status) {
+			throw new Error('It should not show a badge');
+		}
+		if ('Accepted' in status) return 'success';
+		// Only missing 'PendingReview'
+		return 'default';
+	};
+	const badgeText = (status: MembershipStatus | undefined): string => {
+		if (status === undefined || 'Rejected' in status) {
+			throw new Error('It should not show a badge');
+		}
+		if ('Accepted' in status) return '🪪 Member';
+		// Only missing 'PendingReview'
+		return '📤 Pending';
+	};
+</script>
+
+<ListItem>
+	<AvatarSize num={group.stats.member_count} slot="start" />
+	<svelte:fragment slot="main">{group.group_name}</svelte:fragment>
+	<svelte:fragment slot="end">
+		{#if isNotMember}
+			<Button variant="primary" size="sm">Join</Button>
+		{:else if group.is_owner[0]}
+			<Badge variant="primary">👑 Owner</Badge>
+		{:else}
+			<Badge variant={statusVariant(group.membership_status[0])}
+				>{badgeText(group.membership_status[0])}</Badge
+			>
+		{/if}
+	</svelte:fragment>
+</ListItem>

--- a/issuer/frontend/src/lib/components/GroupItemSkeleton.svelte
+++ b/issuer/frontend/src/lib/components/GroupItemSkeleton.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import ListItem from '$lib/ui-components/elements/ListItem.svelte';
+</script>
+
+<ListItem>
+	<div class="placeholder-circle w-12" slot="start" />
+	<div class="placeholder" slot="main" />
+	<div class="w-16" slot="end">
+		<div class="placeholder" />
+	</div>
+</ListItem>

--- a/issuer/frontend/src/lib/components/GroupsList.svelte
+++ b/issuer/frontend/src/lib/components/GroupsList.svelte
@@ -1,30 +1,25 @@
-<script>
-	import AvatarSize from '$lib/ui-components/elements/AvatarSize.svelte';
-	import Badge from '$lib/ui-components/elements/Badge.svelte';
-	import Button from '$lib/ui-components/elements/Button.svelte';
+<script lang="ts">
 	import List from '$lib/ui-components/elements/List.svelte';
-	import ListItem from '$lib/ui-components/elements/ListItem.svelte';
+	import type { PublicGroupData } from '../../declarations/meta_issuer.did';
+	import GroupItem from './GroupItem.svelte';
+	import GroupItemSkeleton from './GroupItemSkeleton.svelte';
+
+	export let groups: PublicGroupData[] | undefined;
+	export let noGroupsMessage: string = 'No groups found';
 </script>
 
-<List>
-	<ListItem>
-		<AvatarSize num={11} slot="start" />
-		<svelte:fragment slot="main">Group A</svelte:fragment>
-		<Badge slot="end" variant="success">Member</Badge>
-	</ListItem>
-	<ListItem>
-		<AvatarSize num={4321} slot="start" />
-		<svelte:fragment slot="main">Group C</svelte:fragment>
-		<Button slot="end" variant="primary" size="sm">Join</Button>
-	</ListItem>
-	<ListItem>
-		<AvatarSize num={4} slot="start" />
-		<svelte:fragment slot="main">Group B</svelte:fragment>
-		<Badge slot="end" variant="default">Pending</Badge>
-	</ListItem>
-	<ListItem>
-		<AvatarSize num={213} slot="start" />
-		<svelte:fragment slot="main">Group C</svelte:fragment>
-		<Button slot="end" variant="primary" size="sm">Join</Button>
-	</ListItem>
-</List>
+{#if groups === undefined}
+	<List>
+		<GroupItemSkeleton />
+		<GroupItemSkeleton />
+		<GroupItemSkeleton />
+	</List>
+{:else if groups?.length === 0}
+	<p>{noGroupsMessage}</p>
+{:else}
+	<List>
+		{#each groups as group}
+			<GroupItem {group} />
+		{/each}
+	</List>
+{/if}

--- a/issuer/frontend/src/lib/ui-components/elements/Badge.svelte
+++ b/issuer/frontend/src/lib/ui-components/elements/Badge.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	type Variant = 'success' | 'default';
+	type Variant = 'success' | 'default' | 'primary';
 	export let variant: Variant;
 
 	let variantClasses: Record<Variant, string> = {
 		success: 'variant-filled-success',
+		primary: 'variant-filled-primary',
 		default: 'variant-filled-surface',
 	};
 </script>

--- a/issuer/frontend/src/lib/ui-components/elements/FooterActionsWrapper.svelte
+++ b/issuer/frontend/src/lib/ui-components/elements/FooterActionsWrapper.svelte
@@ -1,0 +1,8 @@
+<div class="flex flex-col gap-4">
+	<div>
+		<slot />
+	</div>
+	<div class="flex justify-end">
+		<slot name="actions" />
+	</div>
+</div>

--- a/issuer/frontend/src/routes/(app)/home/+page.svelte
+++ b/issuer/frontend/src/routes/(app)/home/+page.svelte
@@ -1,18 +1,84 @@
 <script lang="ts">
-	import GroupsList from "$lib/components/GroupsList.svelte";
-import { Tab, TabGroup } from "@skeletonlabs/skeleton";
+	import GroupsList from '$lib/components/GroupsList.svelte';
+	import Button from '$lib/ui-components/elements/Button.svelte';
+	import FooterActionsWrapper from '$lib/ui-components/elements/FooterActionsWrapper.svelte';
+	import { Tab, TabGroup, localStorageStore } from '@skeletonlabs/skeleton';
+	import type { PublicGroupData } from '../../../declarations/meta_issuer.did';
+	import type { Writable } from 'svelte/store';
 
-	let tabSet = 0;
+	// Persist the selected tab in the local storage.
+	const tabStore: Writable<number> = localStorageStore('groupsTab', 0);
+	let tabSet = $tabStore;
+	$: tabStore.set(tabSet);
+
+	const noMyGroupsMessage =
+		'Create a group to issue Verifiable Credentials that grant people access to funny images on the Relying Party app.';
+
+	// TODO: Replace with data from the backend.
+	const yesterday = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
+	const myGroups: PublicGroupData[] = [
+		{
+			membership_status: [{ Accepted: null }],
+			is_owner: [true],
+			stats: {
+				created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
+				member_count: 11,
+			},
+			group_name: 'Group Z',
+		},
+	];
+	const groups: PublicGroupData[] = [
+		{
+			membership_status: [{ Accepted: null }],
+			is_owner: [false],
+			stats: {
+				created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
+				member_count: 32,
+			},
+			group_name: 'Group A',
+		},
+		{
+			membership_status: [],
+			is_owner: [false],
+			stats: {
+				created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
+				member_count: 705,
+			},
+			group_name: 'Group B',
+		},
+		{
+			membership_status: [{ PendingReview: null }],
+			is_owner: [false],
+			stats: {
+				created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
+				member_count: 0,
+			},
+			group_name: 'Group C',
+		},
+		{
+			membership_status: [{ Rejected: null }],
+			is_owner: [false],
+			stats: {
+				created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
+				member_count: 2100,
+			},
+			group_name: 'Group D',
+		},
+	];
 </script>
+
 <TabGroup justify="justify-center">
 	<Tab bind:group={tabSet} name="all-groups" value={0}>All Groups</Tab>
 	<Tab bind:group={tabSet} name="my-groups" value={1}>My Groups</Tab>
 	<!-- Tab Panels --->
 	<svelte:fragment slot="panel">
 		{#if tabSet === 0}
-			<GroupsList />
+			<GroupsList {groups} />
 		{:else if tabSet === 1}
-			<div>My Groups</div>
+			<FooterActionsWrapper>
+				<GroupsList groups={myGroups} noGroupsMessage={noMyGroupsMessage} />
+				<Button variant="primary" slot="actions">Create Group</Button>
+			</FooterActionsWrapper>
 		{/if}
 	</svelte:fragment>
 </TabGroup>


### PR DESCRIPTION
The main motivation for this PR is to add the UI for "My Groups". This part uses the same component as "All Groups". The only difference is which data is passed.

Therefore, I adapted GroupsList to render based in props.

I also added persistence to the local storage to which tab is selected. The UX was weird if the user refreshed in one tab and was shown another right after.

Also added the logic to show either loading groups or no groups at all.

Also added the "Owner" badge and introduced emojis for the other badges as well.

