### PR TITLE
Add info modals for members and pending members

### DIFF
--- a/issuer/frontend/src/lib/components/GroupItem.svelte
+++ b/issuer/frontend/src/lib/components/GroupItem.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
   import AvatarSize from '$lib/ui-components/elements/AvatarSize.svelte';
   import Badge from '$lib/ui-components/elements/Badge.svelte';
   import Button from '$lib/ui-components/elements/Button.svelte';
   import ListItem from '$lib/ui-components/elements/ListItem.svelte';
   import type { MembershipStatus, PublicGroupData } from '../../declarations/meta_issuer.did';
+  import { getModalStore, type ModalSettings } from '@skeletonlabs/skeleton';
 
   export let group: PublicGroupData;
+  // Must be invoked at the top level: https://www.skeleton.dev/utilities/modals
+  const modalStore = getModalStore();
 
-  let isNotMember: boolean;
-  $: isNotMember = group.membership_status.length === 0 || 'Rejected' in group.membership_status[0];
+  let canJoin: boolean;
+  $: canJoin = group.membership_status.length === 0 || 'Rejected' in group.membership_status[0];
 
   const statusVariant = (status: MembershipStatus | undefined): 'success' | 'default' => {
     if (status === undefined || 'Rejected' in status) {
@@ -26,16 +30,39 @@
     // Only missing 'PendingReview'
     return '📤 Pending';
   };
+
+  const createOpenModal = (modal: 'memberModal' | 'pendingMemberModal') => () => {
+    const meta = { name: group.group_name };
+    const settings: ModalSettings = { type: 'component', component: modal, meta };
+    modalStore.trigger(settings);
+  };
+
+  const getOnClick = (group: PublicGroupData): (() => void) | undefined => {
+    if (group.is_owner[0]) {
+      // TODO: Change empty space for "-" in the URL
+      return () => goto(`/groups/${group.group_name}`);
+    }
+    const status = group.membership_status[0];
+    if (status === undefined || 'Rejected' in status) {
+      return undefined;
+    }
+    if ('Accepted' in status) return createOpenModal('memberModal');
+    // Only missing 'PendingReview'
+    return createOpenModal('pendingMemberModal');
+  };
+
+  let onClick: (() => void) | undefined;
+  $: onClick = getOnClick(group);
 </script>
 
-<ListItem>
+<ListItem {onClick}>
   <AvatarSize num={group.stats.member_count} slot="start" />
   <svelte:fragment slot="main">{group.group_name}</svelte:fragment>
   <svelte:fragment slot="end">
-    {#if isNotMember}
-      <Button variant="primary" size="sm">Join</Button>
-    {:else if group.is_owner[0]}
+    {#if group.is_owner[0]}
       <Badge variant="primary">👑 Owner</Badge>
+    {:else if canJoin}
+      <Button variant="primary" size="sm">Join</Button>
     {:else}
       <Badge variant={statusVariant(group.membership_status[0])}
         >{badgeText(group.membership_status[0])}</Badge

--- a/issuer/frontend/src/lib/modals/MemberModal.svelte
+++ b/issuer/frontend/src/lib/modals/MemberModal.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import Button from '$lib/ui-components/elements/Button.svelte';
+  import Modal from '$lib/ui-components/elements/Modal.svelte';
+  import { getModalStore } from '@skeletonlabs/skeleton';
+
+  const modalStore = getModalStore();
+
+  let groupName: string;
+  $: groupName = $modalStore[0] ? $modalStore[0].meta.name : '';
+</script>
+
+{#if $modalStore[0]}
+  <Modal>
+    <svelte:fragment slot="title">Test Your Credential On the Relying Party</svelte:fragment>
+    <p>
+      {`You are a member ${groupName}. Visit Xxxxx to view content that's only accessible to members of ${groupName}.`}
+    </p>
+    <Button slot="actions" variant="primary" href="https://www.skeleton.dev/"
+      >Test on Relying Party</Button
+    >
+  </Modal>
+{/if}

--- a/issuer/frontend/src/lib/modals/PendingMemberModal.svelte
+++ b/issuer/frontend/src/lib/modals/PendingMemberModal.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Modal from '$lib/ui-components/elements/Modal.svelte';
+  import { getModalStore } from '@skeletonlabs/skeleton';
+
+  const modalStore = getModalStore();
+
+  let groupName: string;
+  $: groupName = $modalStore[0] ? $modalStore[0].meta.name : '';
+</script>
+
+{#if $modalStore[0]}
+  <Modal>
+    <svelte:fragment slot="title">Pending Join Request</svelte:fragment>
+    <p>
+      {`You are not approved for ${groupName} credential yet.`}
+    </p>
+    <p>
+      {`Wait for the owner of the group to approve you.`}
+    </p>
+  </Modal>
+{/if}

--- a/issuer/frontend/src/lib/modals/registry.modals.ts
+++ b/issuer/frontend/src/lib/modals/registry.modals.ts
@@ -1,0 +1,8 @@
+import type { ModalComponent } from '@skeletonlabs/skeleton';
+import MemberModal from './MemberModal.svelte';
+import PendingMemberModal from './PendingMemberModal.svelte';
+
+export const modalRegistry: Record<string, ModalComponent> = {
+  memberModal: { ref: MemberModal },
+  pendingMemberModal: { ref: PendingMemberModal },
+};

--- a/issuer/frontend/src/lib/ui-components/elements/Button.svelte
+++ b/issuer/frontend/src/lib/ui-components/elements/Button.svelte
@@ -3,6 +3,7 @@
   export let variant: Variant;
   export let testId: string | undefined = undefined;
   export let size: 'sm' | 'md' | 'lg' = 'md';
+  export let href: string | undefined = undefined;
 
   let variantClasses: Record<Variant, string> = {
     success: 'variant-filled-success',
@@ -14,9 +15,13 @@
   };
 </script>
 
-<button
-  on:click
-  type="button"
-  class={`btn btn-${size} ${variantClasses[variant]}`}
-  data-tid={testId}><slot /></button
->
+{#if href}
+  <a {href} target="_blank" class={`btn btn-${size} ${variantClasses[variant]}`}><slot /></a>
+{:else}
+  <button
+    on:click
+    type="button"
+    class={`btn btn-${size} ${variantClasses[variant]}`}
+    data-tid={testId}><slot /></button
+  >
+{/if}

--- a/issuer/frontend/src/lib/ui-components/elements/List.svelte
+++ b/issuer/frontend/src/lib/ui-components/elements/List.svelte
@@ -1,3 +1,3 @@
-<ul class="flex flex-col gap-4">
+<ul role="table" class="flex flex-col">
   <slot />
 </ul>

--- a/issuer/frontend/src/lib/ui-components/elements/ListItem.svelte
+++ b/issuer/frontend/src/lib/ui-components/elements/ListItem.svelte
@@ -1,13 +1,32 @@
 <script lang="ts">
+  import IconRight from '../icons/IconRight.svelte';
   import Heading from './Heading.svelte';
+
+  export let onClick: (() => void) | undefined = undefined;
+
+  function handleClick() {
+    if (onClick) {
+      onClick();
+    }
+  }
+  let hoverClass = '';
+  $: hoverClass = onClick ? 'cursor-pointer' : '';
 </script>
 
-<li class="flex justify-between items-center gap-4">
+<li
+  on:click={handleClick}
+  on:keypress={handleClick}
+  role="row"
+  class={`flex justify-between items-center gap-4 p-2 hover:bg-tertiary-hover-token rounded-container-token ${hoverClass}`}
+>
   <slot name="start" />
   <div class="flex-1">
     <Heading level="5"><slot name="main" /></Heading>
   </div>
-  <span class="flex gap-2 align-center">
+  <span class="flex gap-2 items-center">
     <slot name="end" />
+    {#if onClick}
+      <IconRight />
+    {/if}
   </span>
 </li>

--- a/issuer/frontend/src/lib/ui-components/elements/Modal.svelte
+++ b/issuer/frontend/src/lib/ui-components/elements/Modal.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Heading from './Heading.svelte';
+</script>
+
+<div class="flex flex-col gap-6 card p-8 w-modal shadow-xl min-h-96">
+  <Heading level="2"><slot name="title" /></Heading>
+  <div class="flex flex-col gap-2 flex-1">
+    <slot />
+  </div>
+  {#if $$slots.actions}
+    <div class="flex justify-end">
+      <slot name="actions" />
+    </div>
+  {/if}
+</div>

--- a/issuer/frontend/src/lib/ui-components/icons/IconRight.svelte
+++ b/issuer/frontend/src/lib/ui-components/icons/IconRight.svelte
@@ -1,0 +1,10 @@
+<!-- source: DFINITY foundation -->
+<svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} viewBox="0 0 20 20" fill="none">
+  <path
+    d="M8 14L12 10L8 6"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/issuer/frontend/src/routes/(app)/+layout.svelte
+++ b/issuer/frontend/src/routes/(app)/+layout.svelte
@@ -4,13 +4,19 @@
   import MainWrapper from '$lib/ui-components/elements/MainWrapper.svelte';
   import { onMount } from 'svelte';
   import '../../app.postcss';
-  import { AppShell, AppBar } from '@skeletonlabs/skeleton';
+  import { AppShell, AppBar, Modal } from '@skeletonlabs/skeleton';
   import { logout, syncAuth } from '$lib/services/auth.services';
+  import { initializeStores } from '@skeletonlabs/skeleton';
+  import { modalRegistry } from '$lib/modals/registry.modals';
+
+  initializeStores();
 
   onMount(() => {
     syncAuth();
   });
 </script>
+
+<Modal components={modalRegistry} />
 
 <AuthGuard>
   <!-- App Shell -->


### PR DESCRIPTION
The main motivation of this PR was to add the simple functionality of the groups list:
* Open modals when user is pending or a member.
* Navigate to group detail page for users' groups.

Changes made in this PR:
* Logic to add an onClick to ListItem in GroupItem
* New ui element: Modal.
* New modals: MemberModal and PendingMemberModal.
* Add modals registry and pass it to the Modal initialization in the layout.
* Initialize modals in layout.
* Button supports links.
* Move the spacing logic in the List to the ListItem. This is done to have nice hover effects.
* Manage click and add hover effect in ListItem.
* New icon: IconRight.