### PR TITLE
Adapt UI Issuer Detail Page

### DIFF
--- a/issuer/frontend/src/lib/ui-components/page-layouts/DefaultPage.svelte
+++ b/issuer/frontend/src/lib/ui-components/page-layouts/DefaultPage.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <section class="flex flex-col gap-8">
+  <slot name="callout" />
   <Heading level="1">
     <slot name="title" />
   </Heading>

--- a/issuer/frontend/src/routes/(app)/issuers/[slug]/+page.svelte
+++ b/issuer/frontend/src/routes/(app)/issuers/[slug]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import AuthGuard from '$lib/components/AuthGuard.svelte';
   import MembersList from '$lib/components/MembersList.svelte';
+  import Button from '$lib/ui-components/elements/Button.svelte';
   import Callout from '$lib/ui-components/elements/Callout.svelte';
   import HeadingSkeleton from '$lib/ui-components/elements/HeadingSkeleton.svelte';
   import DefaultPage from '$lib/ui-components/page-layouts/DefaultPage.svelte';
@@ -8,12 +9,14 @@
 
 <AuthGuard>
   <DefaultPage>
-    <svelte:fragment slot="title">My Fav Credential</svelte:fragment>
-    <Callout>
+    <Callout slot="callout">
       <p>🎉 You are the issuer of this credential type.</p>
     </Callout>
-    <MembersList members={[]} title="Pending Credentials" />
-    <MembersList members={[]} title="200 Approved Credentials" />
+    <svelte:fragment slot="title">My Fav Credential</svelte:fragment>
+    <div>
+      <Button variant="primary" href="https://www.skeleton.dev/">Test In relying party</Button>
+    </div>
+    <MembersList members={[]} title={`Credentials: 200 approved, 2 pending`} />
   </DefaultPage>
   <DefaultPage slot="skeleton">
     <svelte:fragment slot="title"><HeadingSkeleton size="lg" /></svelte:fragment>


### PR DESCRIPTION
Main motivation is to adapt the Issuer detail page to the new design that has slightly changed.

Changes:
* Add callout above the title.
* Add "Test in RP" button
* Only one list of members (which will need to be sorted by pending requests first.)