### PR TITLE
Change update_membership-API to batch-mode

### DIFF
--- a/issuer/meta_issuer.did
+++ b/issuer/meta_issuer.did
@@ -117,7 +117,6 @@ type TimestampNs = nat64;
 
 type ListGroupsRequest = record {
     group_name_substring : opt text;
-    only_owned : opt bool;
 };
 
 type GetGroupRequest = record {
@@ -133,11 +132,15 @@ type JoinGroupRequest = record {
     note : text
 };
 
+type MembershipUpdate = record {
+  member : principal;
+  new_status : MembershipStatus;
+};
 
 type UpdateMembershipRequest = record {
     group_name : text;
-    member : principal;
-    new_status : MembershipStatus;
+    updates : vec MembershipUpdate;
+
 };
 
 type GroupStats = record {

--- a/issuer/src/groups_api.rs
+++ b/issuer/src/groups_api.rs
@@ -3,7 +3,6 @@ use candid::{CandidType, Deserialize, Principal};
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct ListGroupsRequest {
     pub group_name_substring: Option<String>,
-    pub only_owned: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -23,10 +22,15 @@ pub struct JoinGroupRequest {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub struct UpdateMembershipRequest {
-    pub group_name: String,
+pub struct MembershipUpdate {
     pub member: Principal,
     pub new_status: MembershipStatus,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct UpdateMembershipRequest {
+    pub group_name: String,
+    pub updates: Vec<MembershipUpdate>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Ord, PartialOrd)]

--- a/issuer/src/main.rs
+++ b/issuer/src/main.rs
@@ -323,20 +323,22 @@ fn update_membership(req: UpdateMembershipRequest) -> Result<(), GroupsError> {
                     req.group_name
                 )));
             }
-            if let Some(member_record) = group_record.members.get(&req.member) {
-                group_record.members.insert(
-                    req.member,
-                    MemberRecord {
-                        note: member_record.note.clone(),
-                        joined_timestamp_ns: member_record.joined_timestamp_ns,
-                        membership_status: req.new_status,
-                    },
-                );
-                groups.insert(req.group_name, group_record);
-                Ok(())
-            } else {
-                Err(GroupsError::NotFound(format!("member: {}", req.member)))
+            for update in req.updates {
+                if let Some(member_record) = group_record.members.get(&update.member) {
+                    group_record.members.insert(
+                        update.member,
+                        MemberRecord {
+                            note: member_record.note.clone(),
+                            joined_timestamp_ns: member_record.joined_timestamp_ns,
+                            membership_status: update.new_status,
+                        },
+                    );
+                } else {
+                    return Err(GroupsError::NotFound(format!("member: {}", update.member)));
+                }
             }
+            groups.insert(req.group_name, group_record);
+            Ok(())
         } else {
             Err(GroupsError::NotFound(format!("group: {}", req.group_name)))
         }


### PR DESCRIPTION
Change `update_membership`-API to work with multiple updates in a single call, adjust tests.
Also, remove `ListGroupsRequest.only_owned`-field, as it seems not really needed.