### PR TITLE
Load issuers from backend

### DIFF
--- a/issuer/frontend/src/lib/api/queryGroups.api.ts
+++ b/issuer/frontend/src/lib/api/queryGroups.api.ts
@@ -1,0 +1,16 @@
+import { getMetaIssuerCanister } from '$lib/utils/actor.utils';
+import type { Identity } from '@dfinity/agent';
+import type { PublicGroupData } from '../../declarations/meta_issuer.did';
+
+export const queryGroups = async ({
+  identity,
+}: {
+  identity: Identity;
+}): Promise<PublicGroupData[]> => {
+  const actor = await getMetaIssuerCanister(identity);
+  const response = await actor.list_groups({ only_owned: [], group_name_substring: [] });
+  if ('Ok' in response) {
+    return response.Ok.groups;
+  }
+  throw response.Err;
+};

--- a/issuer/frontend/src/lib/services/create-issuer.services.ts
+++ b/issuer/frontend/src/lib/services/create-issuer.services.ts
@@ -1,6 +1,7 @@
 import { addGroup } from '$lib/api/addGroup.api';
 import { isNullish } from '$lib/utils/is-nullish.utils';
 import type { Identity } from '@dfinity/agent';
+import { loadIssuers } from './load-issuers.services';
 
 export const createIssuer = async ({
   identity,
@@ -14,7 +15,7 @@ export const createIssuer = async ({
       throw new Error('Identity not found');
     }
     await addGroup({ identity, issuerName });
-    // TODO: Load issuer to store and redirect to detail page.
+    await loadIssuers({ identity });
   } catch (err: unknown) {
     console.log('error creating issuer');
     console.error(err);

--- a/issuer/frontend/src/lib/services/load-issuers.services.ts
+++ b/issuer/frontend/src/lib/services/load-issuers.services.ts
@@ -1,0 +1,13 @@
+import { queryGroups } from '$lib/api/queryGroups.api';
+import { getIssuersStore } from '$lib/stores/issuers.store';
+import { type Identity } from '@dfinity/agent';
+
+export const loadIssuers = async ({ identity }: { identity: Identity }) => {
+  try {
+    const groups = await queryGroups({ identity });
+    const issuersStore = getIssuersStore(identity);
+    issuersStore.set(groups);
+  } catch (err: unknown) {
+    // TODO: Handle error
+  }
+};

--- a/issuer/frontend/src/lib/stores/issuers.store.ts
+++ b/issuer/frontend/src/lib/stores/issuers.store.ts
@@ -1,0 +1,56 @@
+import { derived, writable, type Readable, type Writable } from 'svelte/store';
+import type { PublicGroupData } from '../../declarations/meta_issuer.did';
+import { AnonymousIdentity, type Identity } from '@dfinity/agent';
+import { queryGroups } from '$lib/api/queryGroups.api';
+
+const issuers: Record<string, Writable<PublicGroupData[] | undefined>> = {};
+export const getIssuersStore = (
+  identity: Identity | undefined | null
+): Writable<PublicGroupData[] | undefined> => {
+  const identityPrincipal = identity?.getPrincipal().toText() ?? 'no-authenticated-identity';
+  if (!issuers[identityPrincipal]) {
+    issuers[identityPrincipal] = writable<PublicGroupData[] | undefined>(
+      undefined,
+      (_set, update) => {
+        queryGroups({ identity: identity ?? new AnonymousIdentity() }).then((groups) => {
+          update((currentData) => {
+            if (currentData === undefined) {
+              return groups;
+            }
+            return currentData;
+          });
+        });
+      }
+    );
+  }
+  return issuers[identityPrincipal];
+};
+
+export const getAllIssuersStore = (
+  identity: Identity | undefined | null
+): Readable<PublicGroupData[] | undefined> =>
+  derived(getIssuersStore(identity), (issuers) => issuers);
+
+const isIdentityCredential = ({ is_owner, membership_status }: PublicGroupData): boolean => {
+  if (is_owner[0]) {
+    return true;
+  }
+  const status = membership_status[0];
+  if (status === undefined || 'Rejected' in status) {
+    return false;
+  }
+  if ('PendingReview' in status || 'Accepted' in status) {
+    return true;
+  }
+  throw new Error('Unexpected membership status');
+};
+export const getCredentialsStore = (
+  identity: Identity | undefined | null
+): Readable<PublicGroupData[] | undefined> =>
+  derived(getAllIssuersStore(identity), (issuers) => issuers?.filter(isIdentityCredential));
+
+const isOwner = ({ is_owner }: PublicGroupData): boolean => Boolean(is_owner[0]);
+export const getIdentityIssuersStore = (
+  identity: Identity | undefined | null
+): Readable<PublicGroupData[] | undefined> =>
+  derived(getAllIssuersStore(identity), (issuers) => issuers?.filter(isOwner));

--- a/issuer/frontend/src/routes/(app)/home/+page.svelte
+++ b/issuer/frontend/src/routes/(app)/home/+page.svelte
@@ -3,13 +3,17 @@
   import Button from '$lib/ui-components/elements/Button.svelte';
   import FooterActionsWrapper from '$lib/ui-components/elements/FooterActionsWrapper.svelte';
   import { localStorageStore } from '@skeletonlabs/skeleton';
-  import type { PublicGroupData } from '../../../declarations/meta_issuer.did';
   import type { Writable } from 'svelte/store';
   import AuthGuard from '$lib/components/AuthGuard.svelte';
   import Tabs from '$lib/ui-components/elements/Tabs.svelte';
   import { getModalStore, type ModalSettings } from '@skeletonlabs/skeleton';
   import { createIssuer } from '$lib/services/create-issuer.services';
   import { authStore } from '$lib/stores/auth.store';
+  import {
+    getAllIssuersStore,
+    getCredentialsStore,
+    getIdentityIssuersStore,
+  } from '$lib/stores/issuers.store';
 
   const modalStore = getModalStore();
 
@@ -17,6 +21,13 @@
   const tabStore: Writable<number> = localStorageStore('groupsTab', 0);
   let tabSet = $tabStore;
   $: tabStore.set(tabSet);
+
+  let allIssuersStore;
+  $: allIssuersStore = getAllIssuersStore($authStore.identity);
+  let myCredentialsStore;
+  $: myCredentialsStore = getCredentialsStore($authStore.identity);
+  let myIssuersStore;
+  $: myIssuersStore = getIdentityIssuersStore($authStore.identity);
 
   const noMyGroupsMessage =
     'Create a group to issue Verifiable Credentials that grant people access to funny images on the Relying Party app.';
@@ -39,56 +50,6 @@
     };
     modalStore.trigger(settings);
   };
-
-  // TODO: Replace with data from the backend.
-  const yesterday = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
-  const groups: PublicGroupData[] = [
-    {
-      membership_status: [{ Accepted: null }],
-      is_owner: [false],
-      stats: {
-        created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
-        member_count: 32,
-      },
-      group_name: 'Group A',
-    },
-    {
-      membership_status: [],
-      is_owner: [false],
-      stats: {
-        created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
-        member_count: 705,
-      },
-      group_name: 'Group B',
-    },
-    {
-      membership_status: [{ PendingReview: null }],
-      is_owner: [false],
-      stats: {
-        created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
-        member_count: 0,
-      },
-      group_name: 'Group C',
-    },
-    {
-      membership_status: [{ Rejected: null }],
-      is_owner: [false],
-      stats: {
-        created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
-        member_count: 2100,
-      },
-      group_name: 'Group D',
-    },
-    {
-      membership_status: [{ Accepted: null }],
-      is_owner: [true],
-      stats: {
-        created_timestamp_ns: BigInt(yesterday.getTime()) * 1000000n,
-        member_count: 11,
-      },
-      group_name: 'Group Z',
-    },
-  ];
 </script>
 
 <Tabs
@@ -101,12 +62,12 @@
 >
   <AuthGuard>
     {#if tabSet === 0}
-      <IssuersList issuers={groups} />
+      <IssuersList issuers={$allIssuersStore} />
     {:else if tabSet === 1}
-      <IssuersList issuers={groups} noGroupsMessage={noCredentialsMessage} />
+      <IssuersList issuers={$myCredentialsStore} noGroupsMessage={noCredentialsMessage} />
     {:else if tabSet === 2}
       <FooterActionsWrapper>
-        <IssuersList issuers={groups} noGroupsMessage={noMyGroupsMessage} />
+        <IssuersList issuers={$myIssuersStore} noGroupsMessage={noMyGroupsMessage} />
         <Button on:click={openCreateModal} variant="primary" slot="actions">Become an Issuer</Button
         >
       </FooterActionsWrapper>


### PR DESCRIPTION
Main motivation is the connect the data shown in the home page to the backend.

In this PR:
* New api function queryGroups
* New service function loadIssuers
* Use loadIssuers after creating an issuer.
* New issuers store and derived stores that filter the data.
* Use new derived stores in home page.