### PR TITLE
Connect Issuer Detail to backend data

### DIFF
--- a/issuer/frontend/src/lib/api/getGroup.api.ts
+++ b/issuer/frontend/src/lib/api/getGroup.api.ts
@@ -1,0 +1,18 @@
+import { getMetaIssuerCanister } from '$lib/utils/actor.utils';
+import type { Identity } from '@dfinity/agent';
+import type { FullGroupData } from '../../declarations/meta_issuer.did';
+
+export const queryGroup = async ({
+  identity,
+  groupName,
+}: {
+  identity: Identity;
+  groupName: string;
+}): Promise<FullGroupData> => {
+  const canister = await getMetaIssuerCanister(identity);
+  const response = await canister.get_group({ group_name: groupName });
+  if ('Ok' in response) {
+    return response.Ok;
+  }
+  throw response.Err;
+};

--- a/issuer/frontend/src/lib/components/IssuerItem.svelte
+++ b/issuer/frontend/src/lib/components/IssuerItem.svelte
@@ -2,6 +2,7 @@
   import { goto } from '$app/navigation';
   import { requestCredential } from '$lib/services/request-credential.services';
   import { authStore } from '$lib/stores/auth.store';
+  import { ISSUER_PARAM } from '$lib/constants/url-params.constants';
   import Badge from '$lib/ui-components/elements/Badge.svelte';
   import Button from '$lib/ui-components/elements/Button.svelte';
   import ListItem from '$lib/ui-components/elements/ListItem.svelte';
@@ -67,7 +68,7 @@
 
   const getOnClick = (issuer: PublicGroupData): (() => void) | undefined => {
     if (issuer.is_owner[0]) {
-      return () => goto(`/issuers/?issuer=${encodeURIComponent(issuer.group_name)}`);
+      return () => goto(`/issuers/?${ISSUER_PARAM}=${encodeURIComponent(issuer.group_name)}`);
     }
     const status = issuer.membership_status[0];
     if (status === undefined || 'Rejected' in status) {

--- a/issuer/frontend/src/lib/components/MemberItem.svelte
+++ b/issuer/frontend/src/lib/components/MemberItem.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import Button from '$lib/ui-components/elements/Button.svelte';
+  import ListItem from '$lib/ui-components/elements/ListItem.svelte';
+  import type { MemberData } from '../../declarations/meta_issuer.did';
+
+  export let member: MemberData;
+
+  let status: 'pending' | 'approved' | 'revoked';
+  $: status =
+    'Rejected' in member.membership_status
+      ? 'revoked'
+      : 'Accepted' in member.membership_status
+        ? 'approved'
+        : 'pending';
+</script>
+
+<ListItem>
+  <svelte:fragment slot="main">{member.note}</svelte:fragment>
+  <svelte:fragment slot="end">
+    {#if status === 'pending'}
+      <Button variant="success">Approve</Button>
+      <Button variant="error">Decline</Button>
+    {:else}
+      <Button variant="tertiary">Revoke</Button>
+    {/if}
+  </svelte:fragment>
+</ListItem>

--- a/issuer/frontend/src/lib/components/MembersList.svelte
+++ b/issuer/frontend/src/lib/components/MembersList.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import ArticleWrapper from '$lib/ui-components/elements/ArticleWrapper.svelte';
-  import Button from '$lib/ui-components/elements/Button.svelte';
   import HeadingSkeleton from '$lib/ui-components/elements/HeadingSkeleton.svelte';
   import List from '$lib/ui-components/elements/List.svelte';
-  import ListItem from '$lib/ui-components/elements/ListItem.svelte';
   import type { MemberData } from '../../declarations/meta_issuer.did';
+  import MemberItem from './MemberItem.svelte';
   import MemberItemSkeleton from './MemberItemSkeleton.svelte';
 
   export let members: MemberData[] | undefined;
@@ -20,21 +19,15 @@
       <MemberItemSkeleton />
     </List>
   </ArticleWrapper>
+{:else if members.length === 0}
+  <p>There are no credentials requests nor issued credentials yet.</p>
 {:else}
   <ArticleWrapper>
     <svelte:fragment slot="title">{title}</svelte:fragment>
     <List>
-      <ListItem>
-        <svelte:fragment slot="main">Name 1</svelte:fragment>
-        <svelte:fragment slot="end">
-          <Button variant="success">Approve</Button>
-          <Button variant="error">Decline</Button>
-        </svelte:fragment>
-      </ListItem>
-      <ListItem>
-        <svelte:fragment slot="main">Name 2</svelte:fragment>
-        <Button variant="tertiary" slot="end">Revoke</Button>
-      </ListItem>
+      {#each members as member}
+        <MemberItem {member} />
+      {/each}
     </List>
   </ArticleWrapper>
 {/if}

--- a/issuer/frontend/src/lib/constants/url-params.constants.ts
+++ b/issuer/frontend/src/lib/constants/url-params.constants.ts
@@ -1,0 +1,1 @@
+export const ISSUER_PARAM = 'issuer';

--- a/issuer/frontend/src/lib/stores/issuer-detail.store.ts
+++ b/issuer/frontend/src/lib/stores/issuer-detail.store.ts
@@ -1,0 +1,48 @@
+import { writable, type Writable } from 'svelte/store';
+import type { FullGroupData } from '../../declarations/meta_issuer.did';
+import { AnonymousIdentity, type Identity } from '@dfinity/agent';
+import { queryGroup } from '$lib/api/getGroup.api';
+import { isNullish } from '$lib/utils/is-nullish.utils';
+
+export type IssuerDetailStore = Writable<FullGroupData | undefined | null>;
+/**
+ * Record<identity-issuer_name, Writable<FullGroupData | undefined>>
+ */
+const issuers: Record<string, IssuerDetailStore> = {};
+export const getIssuerDetailStore = ({
+  identity,
+  issuerName,
+}: {
+  identity: Identity | undefined | null;
+  issuerName: string;
+}): IssuerDetailStore => {
+  const identityPrincipal = identity?.getPrincipal().toText() ?? 'no-authenticated-identity';
+  const key = `${identityPrincipal}-${issuerName}`;
+  if (!issuers[key]) {
+    issuers[key] = writable<FullGroupData | undefined | null>(undefined, (_set, update) => {
+      // No need to query if we don't have the identity
+      if (isNullish(identity)) {
+        return;
+      }
+      queryGroup({ identity: identity ?? new AnonymousIdentity(), groupName: issuerName })
+        .then((group) => {
+          update((currentData) => {
+            if (currentData === undefined) {
+              return group;
+            }
+            return currentData;
+          });
+        })
+        .catch((error) => {
+          console.error('Error fetching issuer detail', error);
+          update((currentData) => {
+            if (currentData === undefined) {
+              return null;
+            }
+            return currentData;
+          });
+        });
+    });
+  }
+  return issuers[key];
+};

--- a/issuer/frontend/src/lib/utils/count-approved-credentials.utils.ts
+++ b/issuer/frontend/src/lib/utils/count-approved-credentials.utils.ts
@@ -1,0 +1,9 @@
+import type { MemberData } from '../../declarations/meta_issuer.did';
+
+const countStatusCredentials =
+  (statusKey: 'Accepted' | 'Rejected' | 'PendingReview') =>
+  (members: MemberData[]): number =>
+    members.filter(({ membership_status }) => statusKey in membership_status).length;
+
+export const countApprovedCredentials = countStatusCredentials('Accepted');
+export const countPendingCredentials = countStatusCredentials('PendingReview');

--- a/issuer/frontend/src/routes/(app)/issuers/+page.svelte
+++ b/issuer/frontend/src/routes/(app)/issuers/+page.svelte
@@ -1,10 +1,45 @@
 <script lang="ts">
   import AuthGuard from '$lib/components/AuthGuard.svelte';
   import MembersList from '$lib/components/MembersList.svelte';
+  import { authStore } from '$lib/stores/auth.store';
+  import { getIssuerDetailStore, type IssuerDetailStore } from '$lib/stores/issuer-detail.store';
   import Button from '$lib/ui-components/elements/Button.svelte';
   import Callout from '$lib/ui-components/elements/Callout.svelte';
   import HeadingSkeleton from '$lib/ui-components/elements/HeadingSkeleton.svelte';
   import DefaultPage from '$lib/ui-components/page-layouts/DefaultPage.svelte';
+  import { page } from '$app/stores';
+  import { ISSUER_PARAM } from '$lib/constants/url-params.constants';
+  import { goto } from '$app/navigation';
+  import {
+    countApprovedCredentials,
+    countPendingCredentials,
+  } from '$lib/utils/count-approved-credentials.utils';
+
+  let issuerName: string | null;
+  $: issuerName = $page.url.searchParams.get(ISSUER_PARAM);
+
+  $: {
+    if (issuerName === null) {
+      goto('/');
+    }
+  }
+
+  let issuerStore: IssuerDetailStore;
+  $: issuerStore = getIssuerDetailStore({
+    identity: $authStore.identity,
+    issuerName: issuerName ?? '',
+  });
+
+  $: {
+    if ($issuerStore === null) {
+      goto('/');
+    }
+  }
+
+  let approvedCredentials: number;
+  $: approvedCredentials = countApprovedCredentials($issuerStore?.members ?? []);
+  let pendingCredentials: number;
+  $: pendingCredentials = countPendingCredentials($issuerStore?.members ?? []);
 </script>
 
 <AuthGuard>
@@ -12,11 +47,14 @@
     <Callout slot="callout">
       <p>🎉 You are the issuer of this credential type.</p>
     </Callout>
-    <svelte:fragment slot="title">My Fav Credential</svelte:fragment>
+    <svelte:fragment slot="title">{$issuerStore?.group_name}</svelte:fragment>
     <div>
       <Button variant="primary" href="https://www.skeleton.dev/">Test In relying party</Button>
     </div>
-    <MembersList members={[]} title={`Credentials: 200 approved, 2 pending`} />
+    <MembersList
+      members={$issuerStore?.members}
+      title={`Credentials: ${approvedCredentials} approved${pendingCredentials > 0 ? `, ${pendingCredentials} pending.` : '.'}`}
+    />
   </DefaultPage>
   <DefaultPage slot="skeleton">
     <svelte:fragment slot="title"><HeadingSkeleton size="lg" /></svelte:fragment>


### PR DESCRIPTION
Main motivation is the connect the issuer detail page to data from the backend.

In this PR:
* New store issuerDetailStore that fetches its data.
* New api queryGroup.
* New component MemberItem.
* Get the issuer query param from the URL and the store based on that in the IssuerDetail page.
* Use the issuerDetailStore to pass data in the IssuerDetail page.
* A couple of convenient utils.
* Handle edge case with no members in the members list.