### PR TITLE
Add Profanity Filter

### DIFF
--- a/issuer/frontend/package-lock.json
+++ b/issuer/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@dfinity/agent": "^1.0.1",
         "@dfinity/auth-client": "^1.0.1",
-        "@dfinity/principal": "^1.1.0"
+        "@dfinity/principal": "^1.1.0",
+        "no-profanity": "^1.5.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.28.1",
@@ -3463,6 +3464,14 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/no-profanity": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/no-profanity/-/no-profanity-1.5.1.tgz",
+      "integrity": "sha512-WHUWSXRSobqcYD++EGgxXU7asFcECICUSiDfrpzK5c+V2luNVZp2vAas0yje45CC3XPkZb6J0CRIMyEZLQK2sg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.14",

--- a/issuer/frontend/package.json
+++ b/issuer/frontend/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@dfinity/agent": "^1.0.1",
     "@dfinity/auth-client": "^1.0.1",
-    "@dfinity/principal": "^1.1.0"
+    "@dfinity/principal": "^1.1.0",
+    "no-profanity": "^1.5.1"
   }
 }

--- a/issuer/frontend/src/lib/components/IssuerItem.svelte
+++ b/issuer/frontend/src/lib/components/IssuerItem.svelte
@@ -7,11 +7,12 @@
   import Button from '$lib/ui-components/elements/Button.svelte';
   import ListItem from '$lib/ui-components/elements/ListItem.svelte';
   import type { MembershipStatus, PublicGroupData } from '../../declarations/meta_issuer.did';
-  import { getModalStore, type ModalSettings } from '@skeletonlabs/skeleton';
+  import { getModalStore, getToastStore, type ModalSettings } from '@skeletonlabs/skeleton';
 
   export let issuer: PublicGroupData;
   // Must be invoked at the top level: https://www.skeleton.dev/utilities/modals
   const modalStore = getModalStore();
+  const toastStore = getToastStore();
 
   let canJoin: boolean;
   $: canJoin = issuer.membership_status.length === 0 || 'Rejected' in issuer.membership_status[0];
@@ -95,6 +96,7 @@
           identity: $authStore.identity,
           issuerName: issuer.group_name,
           note,
+          toastStore,
         });
         loadingRequestCredential = false;
       },

--- a/issuer/frontend/src/lib/constants/messages.ts
+++ b/issuer/frontend/src/lib/constants/messages.ts
@@ -1,0 +1,4 @@
+export const PROFANITY_MESSAGE =
+  'Oops! Your chosen nickname contains words we try to keep out of our friendly community. Please pick a different one. Thank you for understanding!';
+export const NO_IDENTITY_MESSAGE =
+  "Oops! It looks like you're not logged in yet. Please log in with Internet Identity and try again. Thanks for your understanding!";

--- a/issuer/frontend/src/lib/services/create-issuer.services.ts
+++ b/issuer/frontend/src/lib/services/create-issuer.services.ts
@@ -2,23 +2,33 @@ import { addGroup } from '$lib/api/addGroup.api';
 import { isNullish } from '$lib/utils/is-nullish.utils';
 import type { Identity } from '@dfinity/agent';
 import { loadIssuers } from './load-issuers.services';
+import { isProfane } from 'no-profanity';
+import type { ToastStore } from '@skeletonlabs/skeleton';
+import { NO_IDENTITY_MESSAGE, PROFANITY_MESSAGE } from '$lib/constants/messages';
 
 export const createIssuer = async ({
   identity,
   issuerName,
+  toastStore,
 }: {
   identity: Identity | null | undefined;
   issuerName: string;
+  toastStore: ToastStore;
 }) => {
   try {
     if (isNullish(identity)) {
-      throw new Error('Identity not found');
+      throw new Error(NO_IDENTITY_MESSAGE);
+    }
+    if (isProfane(issuerName)) {
+      throw new Error(PROFANITY_MESSAGE);
     }
     await addGroup({ identity, issuerName });
     await loadIssuers({ identity });
   } catch (err: unknown) {
-    console.log('error creating issuer');
     console.error(err);
-    // TODO: Handle error
+    toastStore.trigger({
+      message: (err as Error).message ?? 'There was an error creating the issuer',
+      background: 'variant-filled-error',
+    });
   }
 };

--- a/issuer/frontend/src/lib/services/manage-membership.services.ts
+++ b/issuer/frontend/src/lib/services/manage-membership.services.ts
@@ -3,6 +3,7 @@ import type { Identity } from '@dfinity/agent';
 import type { Principal } from '@dfinity/principal';
 import { loadIssuerDetail } from './load-issuer-detail.services';
 import type { MembershipStatus } from '../../declarations/meta_issuer.did';
+import { NO_IDENTITY_MESSAGE } from '$lib/constants/messages';
 
 const updaterFactory =
   (newStatus: MembershipStatus) =>
@@ -17,7 +18,7 @@ const updaterFactory =
   }) => {
     try {
       if (!identity) {
-        throw new Error('No identity');
+        throw new Error(NO_IDENTITY_MESSAGE);
       }
       await updateMembership({
         identity,

--- a/issuer/frontend/src/lib/services/request-credential.services.ts
+++ b/issuer/frontend/src/lib/services/request-credential.services.ts
@@ -2,25 +2,35 @@ import { isNullish } from '$lib/utils/is-nullish.utils';
 import type { Identity } from '@dfinity/agent';
 import { loadIssuers } from './load-issuers.services';
 import { joinGroup } from '$lib/api/joinGroup.api';
+import { isProfane } from 'no-profanity';
+import type { ToastStore } from '@skeletonlabs/skeleton';
+import { NO_IDENTITY_MESSAGE, PROFANITY_MESSAGE } from '$lib/constants/messages';
 
 export const requestCredential = async ({
   identity,
   issuerName,
   note,
+  toastStore,
 }: {
   identity: Identity | null | undefined;
   issuerName: string;
   note: string;
+  toastStore: ToastStore;
 }) => {
   try {
     if (isNullish(identity)) {
-      throw new Error('Identity not found');
+      throw new Error(NO_IDENTITY_MESSAGE);
+    }
+    if (isProfane(note)) {
+      throw new Error(PROFANITY_MESSAGE);
     }
     await joinGroup({ identity, issuerName, note });
     await loadIssuers({ identity });
   } catch (err: unknown) {
-    console.log('error creating issuer');
     console.error(err);
-    // TODO: Handle error
+    toastStore.trigger({
+      message: (err as Error).message ?? 'There was an error requesting the credential.',
+      background: 'variant-filled-error',
+    });
   }
 };

--- a/issuer/frontend/src/routes/(app)/+layout.svelte
+++ b/issuer/frontend/src/routes/(app)/+layout.svelte
@@ -3,7 +3,7 @@
   import MainWrapper from '$lib/ui-components/elements/MainWrapper.svelte';
   import { onMount } from 'svelte';
   import '../../app.postcss';
-  import { AppShell, AppBar, Modal } from '@skeletonlabs/skeleton';
+  import { AppShell, AppBar, Modal, Toast } from '@skeletonlabs/skeleton';
   import { logout, syncAuth } from '$lib/services/auth.services';
   import { initializeStores } from '@skeletonlabs/skeleton';
 
@@ -15,6 +15,7 @@
 </script>
 
 <Modal />
+<Toast />
 
 <!-- App Shell -->
 <AppShell>

--- a/issuer/frontend/src/routes/(app)/home/+page.svelte
+++ b/issuer/frontend/src/routes/(app)/home/+page.svelte
@@ -2,7 +2,7 @@
   import IssuersList from '$lib/components/IssuersList.svelte';
   import Button from '$lib/ui-components/elements/Button.svelte';
   import FooterActionsWrapper from '$lib/ui-components/elements/FooterActionsWrapper.svelte';
-  import { localStorageStore } from '@skeletonlabs/skeleton';
+  import { getToastStore, localStorageStore } from '@skeletonlabs/skeleton';
   import type { Writable } from 'svelte/store';
   import AuthGuard from '$lib/components/AuthGuard.svelte';
   import Tabs from '$lib/ui-components/elements/Tabs.svelte';
@@ -16,6 +16,7 @@
   } from '$lib/stores/issuers.store';
 
   const modalStore = getModalStore();
+  const toastStore = getToastStore();
 
   // Persist the selected tab in the local storage.
   const tabStore: Writable<number> = localStorageStore('groupsTab', 0);
@@ -47,6 +48,7 @@
         await createIssuer({
           identity: $authStore.identity,
           issuerName,
+          toastStore,
         });
         loadingCreateIssuer = false;
       },


### PR DESCRIPTION
Main motivation is to prevent users from writing profanity when requesting credentials and creating issuers.

We want a simple solution: a library with a list of words that tells us whether the text contains profanity or not.

In this PR:
* Install "no-profanity" npm package.
* Use the package when requesting credential for the note and when creating an issuer for the name. Show a toast when there is an error in those services.
* Setup `Toast` in the layout to show toasts.
* Pass the toastStore to the services to trigger toasts. Unfortunately, the toastStore needs to be initialized within a component.
* Add a constant file for common messages.