### PR TITLE
Sort credentials and issuers

### DIFF
--- a/issuer/frontend/src/lib/components/IssuerItem.svelte
+++ b/issuer/frontend/src/lib/components/IssuerItem.svelte
@@ -8,6 +8,7 @@
   import ListItem from '$lib/ui-components/elements/ListItem.svelte';
   import type { MembershipStatus, PublicGroupData } from '../../declarations/meta_issuer.did';
   import { getModalStore, getToastStore, type ModalSettings } from '@skeletonlabs/skeleton';
+  import { nanoSecondsToDateTime } from '$lib/utils/date.utils';
 
   export let issuer: PublicGroupData;
   // Must be invoked at the top level: https://www.skeleton.dev/utilities/modals
@@ -112,6 +113,7 @@
 
 <ListItem {onClick}>
   <svelte:fragment slot="main">{issuer.group_name}</svelte:fragment>
+  <span slot="sub">{`Created ${nanoSecondsToDateTime(issuer.stats.created_timestamp_ns)}`}</span>
   <svelte:fragment slot="end">
     {#if issuer.is_owner[0]}
       <Badge variant="primary">👑 Owner</Badge>

--- a/issuer/frontend/src/lib/components/MemberItem.svelte
+++ b/issuer/frontend/src/lib/components/MemberItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Principal } from '@dfinity/principal';
   import { acceptCredential, revokeCredential } from '$lib/services/manage-membership.services';
   import { authStore } from '$lib/stores/auth.store';
   import Badge from '$lib/ui-components/elements/Badge.svelte';
@@ -8,6 +9,9 @@
 
   export let issuerName: string;
   export let member: MemberData;
+
+  let currentUserPrincipal: Principal | undefined | null;
+  $: currentUserPrincipal = $authStore.identity?.getPrincipal();
 
   let status: 'pending' | 'approved' | 'revoked';
   $: status =
@@ -50,6 +54,8 @@
       <Button variant="error" on:click={revoke} loading={loadingRevoke} disabled={loadingAccept}
         >Decline</Button
       >
+    {:else if member.member.toText() === currentUserPrincipal?.toText()}
+      <Badge variant="primary">👑</Badge>
     {:else if status === 'approved'}
       <Button variant="secondary" on:click={revoke} loading={loadingRevoke}>Revoke</Button>
     {:else}

--- a/issuer/frontend/src/lib/stores/issuers.store.ts
+++ b/issuer/frontend/src/lib/stores/issuers.store.ts
@@ -24,10 +24,14 @@ export const getIssuersStore = (
   return issuers[identityPrincipal];
 };
 
+const sortCredentialsPerTimestampDescending = (a: PublicGroupData, b: PublicGroupData): number =>
+  Number(b.stats.created_timestamp_ns - a.stats.created_timestamp_ns);
 export const getAllIssuersStore = (
   identity: Identity | undefined | null
 ): Readable<PublicGroupData[] | undefined> =>
-  derived(getIssuersStore(identity), (issuers) => issuers);
+  derived(getIssuersStore(identity), (issuers) =>
+    issuers?.sort(sortCredentialsPerTimestampDescending)
+  );
 
 const isIdentityCredential = ({ is_owner, membership_status }: PublicGroupData): boolean => {
   if (is_owner[0]) {

--- a/issuer/frontend/src/lib/ui-components/elements/ListItem.svelte
+++ b/issuer/frontend/src/lib/ui-components/elements/ListItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import IconRight from '../icons/IconRight.svelte';
   import Heading from './Heading.svelte';
+  import Stack from './Stack.svelte';
 
   export let onClick: (() => void) | undefined = undefined;
 
@@ -21,7 +22,12 @@
 >
   <slot name="start" />
   <div class="flex-1">
-    <Heading level="5"><slot name="main" /></Heading>
+    <Stack>
+      <Heading level="5"><slot name="main" /></Heading>
+      {#if $$slots.sub}
+        <span class="text-sm text-surface-500"><slot name="sub" /></span>
+      {/if}
+    </Stack>
   </div>
   <span class="flex gap-2 items-center">
     <slot name="end" />

--- a/issuer/frontend/src/lib/ui-components/elements/Stack.svelte
+++ b/issuer/frontend/src/lib/ui-components/elements/Stack.svelte
@@ -1,0 +1,3 @@
+<div class="flex flex-col gap-2">
+  <slot />
+</div>

--- a/issuer/frontend/src/lib/utils/date.utils.ts
+++ b/issuer/frontend/src/lib/utils/date.utils.ts
@@ -1,0 +1,24 @@
+const secondsToTime = (seconds: number): string => {
+  const options: Intl.DateTimeFormatOptions = {
+    timeStyle: 'short',
+  };
+  const milliseconds = seconds * 1000;
+  // We only support english for now.
+  return new Date(milliseconds).toLocaleTimeString('en', options);
+};
+
+const secondsToDate = (seconds: number): string => {
+  const options: Intl.DateTimeFormatOptions = {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  };
+  const milliseconds = seconds * 1000;
+  // We only support english for now.
+  return new Date(milliseconds).toLocaleDateString('en', options);
+};
+
+export const nanoSecondsToDateTime = (nanoSeconds: bigint): string => {
+  const seconds = Number(nanoSeconds / BigInt(1e9));
+  return `${secondsToDate(seconds)} ${secondsToTime(seconds)}`;
+};


### PR DESCRIPTION
Main motivation is to sort the issuers and credentials list to make it more user friendly.

In this PR:
* Issuers are sorted by descending order of creation.
* The owner can't revoke their credential.
* Members are sorted first by status then by order of joined timestamp.
* Add creation timestamp to credential.