### PR TITLE
Access Exclusive Content Flow UI

### DIFF
--- a/rp/frontend/src/lib/components/ChooseImageModal.svelte
+++ b/rp/frontend/src/lib/components/ChooseImageModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getModalStore } from '@skeletonlabs/skeleton';
+  import Modal from './Modal.svelte';
 
   /* eslint-disable-next-line */
   export let parent: any;
@@ -24,13 +25,8 @@
   };
 </script>
 
-<div
-  class="modal block overflow-y-auto bg-surface-100-800-token w-modal h-auto p-4 space-y-4 rounded-container-token shadow-xl"
-  role="dialog"
-  aria-modal="true"
-  aria-label="Choose Image"
->
-  <header class="modal-header text-2xl font-bold">Choose Image</header>
+<Modal>
+  <svelte:fragment slot="header">Choose Image</svelte:fragment>
   <article class="grid grid-cols-2 md:grid-cols-3 gap-4">
     {#each images as image}
       <a href={'#'} on:click={selectImageFactory(image)}>
@@ -38,4 +34,4 @@
       </a>
     {/each}
   </article>
-</div>
+</Modal>

--- a/rp/frontend/src/lib/components/ImagesGrid.svelte
+++ b/rp/frontend/src/lib/components/ImagesGrid.svelte
@@ -1,16 +1,28 @@
 <script lang="ts">
+  import { getModalStore, type ModalSettings } from '@skeletonlabs/skeleton';
   import Button from './Button.svelte';
 
-  export let images: string[] = [];
+  export let images: { imageUrl: string; issuerName: string }[] = [];
+
+  const modalStore = getModalStore();
+
+  const openImageFactory = (image: { imageUrl: string; issuerName: string }) => () => {
+    const modal: ModalSettings = {
+      type: 'component',
+      component: 'viewExclusiveContentModal',
+      meta: { image },
+    };
+    modalStore.trigger(modal);
+  };
 </script>
 
 <section class="grid grid-cols-2 md:grid-cols-3 gap-4">
   {#each images as image}
     <div class="relative">
       <div class="absolute -top-0 -left-0 w-full flex flex-col items-center py-2 px-2 h-full">
-        <h5 class="h5">{image}</h5>
+        <h5 class="h5">{image.issuerName}</h5>
         <div class="flex-1 flex justify-center items-center">
-          <Button variant="ghost">View</Button>
+          <Button variant="ghost" on:click={openImageFactory(image)}>View</Button>
         </div>
         <p class="text-sm self-start">1 minute ago</p>
       </div>

--- a/rp/frontend/src/lib/components/Modal.svelte
+++ b/rp/frontend/src/lib/components/Modal.svelte
@@ -1,0 +1,11 @@
+<div
+  class="modal block overflow-y-auto bg-surface-100-800-token w-modal h-auto p-4 space-y-4 rounded-container-token shadow-xl"
+  role="dialog"
+  aria-modal="true"
+>
+  <header class="modal-header text-2xl font-bold"><slot name="header" /></header>
+  <slot />
+  <div class="modal-footer flex justify-end space-x-2">
+    <slot name="footer" />
+  </div>
+</div>

--- a/rp/frontend/src/lib/components/ViewExclusiveContentModal.svelte
+++ b/rp/frontend/src/lib/components/ViewExclusiveContentModal.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  /* eslint-disable svelte/no-at-html-tags */
+  import { getModalStore } from '@skeletonlabs/skeleton';
+  import Modal from './Modal.svelte';
+  import Button from './Button.svelte';
+
+  /* eslint-disable-next-line */
+  export let parent: any;
+
+  const modalStore = getModalStore();
+
+  const issuerName = 'Photo Gallery';
+  const imageUrl = $modalStore[0]?.meta.image.imageUrl;
+
+  const close = () => {
+    parent.onClose();
+  };
+</script>
+
+<Modal>
+  <svelte:fragment slot="header">Choose Image</svelte:fragment>
+  <div class="flex flex-col">
+    {#if imageUrl}
+      <div class="sm:px-36">
+        <img class="h-auto max-w-full rounded-lg" src={imageUrl} alt="Visible" />
+      </div>
+    {:else}
+      <p>{@html `You did not prove you hold the <em>${issuerName}</em> credential.`}</p>
+      <p>
+        {@html `If you want to access the image, request the <em>${issuerName}</em> credential from the issuer and share your credential with the demo relying party.`}
+      </p>
+    {/if}
+  </div>
+  <Button slot="footer" on:click={close} variant="ghost">Close</Button>
+</Modal>

--- a/rp/frontend/src/routes/+layout.svelte
+++ b/rp/frontend/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import Button from '$lib/components/Button.svelte';
   import ChooseImageModal from '$lib/components/ChooseImageModal.svelte';
   import MainWrapper from '$lib/components/MainWrapper.svelte';
+  import ViewExclusiveContentModal from '$lib/components/ViewExclusiveContentModal.svelte';
   import '../app.postcss';
   import {
     AppShell,
@@ -15,7 +16,8 @@
   initializeStores();
 
   const modalRegistry: Record<string, ModalComponent> = {
-    modalChooseImage: { ref: ChooseImageModal },
+    chooseImageModal: { ref: ChooseImageModal },
+    viewExclusiveContentModal: { ref: ViewExclusiveContentModal },
   };
 </script>
 

--- a/rp/frontend/src/routes/+page.svelte
+++ b/rp/frontend/src/routes/+page.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
   import ImagesGrid from '$lib/components/ImagesGrid.svelte';
 
-  let contentImages: string[] = Array.from({ length: 10 }, (_, i) => `Test ${i}`);
+  const contentImages: { imageUrl: string; issuerName: string }[] = [
+    'https://images.unsplash.com/photo-1617296538902-887900d9b592?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzExMDB8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+    'https://images.unsplash.com/photo-1597077962467-be16edcc6a43?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2MzZ8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+    'https://images.unsplash.com/photo-1553184570-557b84a3a308?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2NTF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+    'https://images.unsplash.com/photo-1509130446053-899ae7358ce6?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2NjF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+    'https://images.unsplash.com/photo-1620005839871-7ac4aed5ddbc?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2NzN8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+    'https://images.unsplash.com/photo-1597531072931-8fceba101e4e?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2OTB8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+    'https://images.unsplash.com/photo-1510111652602-195fc654aa83?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY0Nzl8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+    'https://images.unsplash.com/photo-1612145342709-eadb6e22acca?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY3MDh8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+    'https://images.unsplash.com/photo-1597077917598-97ca3922a317?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY3MjF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+  ].map((imageUrl, i) => ({ issuerName: `Photo Gallery ${i}`, imageUrl }));
 </script>
 
 <h1 class="h1 text-center">View and Share Content</h1>

--- a/rp/frontend/src/routes/share/+page.svelte
+++ b/rp/frontend/src/routes/share/+page.svelte
@@ -14,7 +14,7 @@
   const openChooseImageModal = () => {
     const modal: ModalSettings = {
       type: 'component',
-      component: 'modalChooseImage',
+      component: 'chooseImageModal',
       response: (r: unknown) => {
         if (r) {
           selectedImage = r as string;


### PR DESCRIPTION
Main motivation is to add the flow that will be used to show the exclusive content after the VC flow.

In this PR:
* Add a "Close" button to the modals.
* New component Modal shared across modals.
* On click the "View" button on images it opens the modal and shows the image that was clicked.
* Change the mock data.
* Rename the keys in the modal initialization to follow the name of the component.