### PR TITLE
Truncate long credentials

### DIFF
--- a/rp/frontend/src/lib/components/ImagesGrid.svelte
+++ b/rp/frontend/src/lib/components/ImagesGrid.svelte
@@ -27,7 +27,7 @@
   {#each images as image}
     <div class="relative">
       <div class="absolute -top-0 -left-0 w-full flex flex-col items-center py-2 px-2 h-full">
-        <h5 class="h5">{image.issuerName}</h5>
+        <h5 class="h5 truncate w-full">{image.issuerName}</h5>
         <div class="flex-1 flex justify-center items-center">
           <Button variant="ghost-primary" on:click={openImageFactory(image)}>View</Button>
         </div>

--- a/rp/frontend/src/routes/+page.svelte
+++ b/rp/frontend/src/routes/+page.svelte
@@ -11,7 +11,7 @@
     'https://images.unsplash.com/photo-1510111652602-195fc654aa83?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY0Nzl8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
     'https://images.unsplash.com/photo-1612145342709-eadb6e22acca?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY3MDh8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
     'https://images.unsplash.com/photo-1597077917598-97ca3922a317?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY3MjF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-  ].map((imageUrl, i) => ({ issuerName: `Photo Gallery ${i}`, imageUrl }));
+  ].map((imageUrl, i) => ({ issuerName: `Photo Gallery with a very long name ${i}`, imageUrl }));
 </script>
 
 <h1 class="h1 text-center">View and Share Content</h1>


### PR DESCRIPTION
The main motivation is to limit credentials name to one line. Using ellipsis for longer names.