### PR TITLE
Home functionality

### DIFF
--- a/rp/frontend/src/lib/api/queryExclusiveContent.api.ts
+++ b/rp/frontend/src/lib/api/queryExclusiveContent.api.ts
@@ -1,0 +1,49 @@
+import type { Identity } from '@dfinity/agent';
+import type { ExclusiveContentList, ContentData } from '../../declarations/rp/rp.did';
+import { Principal } from '@dfinity/principal';
+
+const credentialName = [
+  'Best Credential Ever',
+  '500 year gang',
+  'The Cool Kids',
+  'The Elite',
+  'The 1%',
+];
+const lastWeek = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).getTime();
+const oneDay = 24 * 60 * 60 * 1000;
+
+const images: ContentData[] = [
+  'https://images.unsplash.com/photo-1617296538902-887900d9b592?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzExMDB8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+  'https://images.unsplash.com/photo-1597077962467-be16edcc6a43?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2MzZ8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+  'https://images.unsplash.com/photo-1553184570-557b84a3a308?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2NTF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+  'https://images.unsplash.com/photo-1509130446053-899ae7358ce6?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2NjF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+  'https://images.unsplash.com/photo-1620005839871-7ac4aed5ddbc?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2NzN8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+  'https://images.unsplash.com/photo-1597531072931-8fceba101e4e?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2OTB8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+  'https://images.unsplash.com/photo-1510111652602-195fc654aa83?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY0Nzl8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+  'https://images.unsplash.com/photo-1612145342709-eadb6e22acca?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY3MDh8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+  'https://images.unsplash.com/photo-1597077917598-97ca3922a317?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY3MjF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
+].map((url, i) => ({
+  url,
+  owner: Principal.fromText('rrkah-fqaaa-aaaaa-aaaaq-cai'),
+  credential_group_name: credentialName[i % credentialName.length],
+  created_timestamp_ns: BigInt(lastWeek + i * oneDay) * BigInt(1e6),
+}));
+
+// TODO: Use call to actor method to get exclusive content
+/* eslint-disable-next-line */
+export const queryExclusiveContent = async ({
+  identity,
+}: {
+  identity: Identity;
+}): Promise<ExclusiveContentList> => {
+  console.log('queryExclusiveContent', identity.getPrincipal().toText());
+  return {
+    content_items: images,
+  };
+  // const actor = await getRpCanister(identity);
+  // await actor.list_images({ group_name_substring: [] });
+  // if ('Ok' in response) {
+  //   return response.Ok;
+  // }
+  // throw response.Err;
+};

--- a/rp/frontend/src/lib/components/ImagesGrid.svelte
+++ b/rp/frontend/src/lib/components/ImagesGrid.svelte
@@ -4,17 +4,19 @@
   import { authStore } from '$lib/stores/auth.store';
   import { nonNullish } from '$lib/utils/non-nullish';
   import { login } from '$lib/services/auth.services';
+  import type { ContentData } from '../../declarations/rp/rp.did';
+  import { nanoSecondsToDateTime } from '$lib/utils/date.utils';
 
-  export let images: { imageUrl: string; issuerName: string }[] = [];
+  export let images: ContentData[] = [];
 
   const modalStore = getModalStore();
 
-  const openImageFactory = (image: { imageUrl: string; issuerName: string }) => () => {
+  const openImageFactory = (content: ContentData) => () => {
     if (nonNullish($authStore.identity)) {
       const modal: ModalSettings = {
         type: 'component',
         component: 'viewExclusiveContentModal',
-        meta: { image },
+        meta: { content, issuerName: content.credential_group_name },
       };
       modalStore.trigger(modal);
     } else {
@@ -25,13 +27,14 @@
 
 <section class="grid grid-cols-2 md:grid-cols-3 gap-4">
   {#each images as image}
+    <!-- TODO: Show image if the user has the credential -->
     <div class="relative">
       <div class="absolute -top-0 -left-0 w-full flex flex-col items-center py-2 px-2 h-full">
-        <h5 class="h5 truncate w-full">{image.issuerName}</h5>
+        <h5 class="h5 truncate w-full">{image.credential_group_name}</h5>
         <div class="flex-1 flex justify-center items-center">
           <Button variant="ghost-primary" on:click={openImageFactory(image)}>View</Button>
         </div>
-        <p class="text-sm self-start">1 minute ago</p>
+        <p class="text-sm self-start">{nanoSecondsToDateTime(image.created_timestamp_ns)}</p>
       </div>
       <div
         class="h-auto max-w-full rounded-lg aspect-square bg-gradient-to-b from-primary-500 to-secondary-500"

--- a/rp/frontend/src/lib/components/ViewExclusiveContentModal.svelte
+++ b/rp/frontend/src/lib/components/ViewExclusiveContentModal.svelte
@@ -9,8 +9,10 @@
 
   const modalStore = getModalStore();
 
-  const issuerName = 'Photo Gallery';
-  const imageUrl = $modalStore[0]?.meta.image.imageUrl;
+  let issuerName = '';
+  $: issuerName = $modalStore[0]?.meta.issuerName;
+  let imageUrl = '';
+  $: imageUrl = $modalStore[0]?.meta.content.url;
 
   const close = () => {
     parent.onClose();
@@ -31,5 +33,5 @@
       </p>
     {/if}
   </div>
-  <Button slot="footer" on:click={close} variant="ghost">Close</Button>
+  <Button slot="footer" on:click={close} variant="ghost-primary">Close</Button>
 </Modal>

--- a/rp/frontend/src/lib/stores/content-data.store.ts
+++ b/rp/frontend/src/lib/stores/content-data.store.ts
@@ -1,0 +1,31 @@
+import { derived, writable, type Readable, type Writable } from 'svelte/store';
+import { AnonymousIdentity, type Identity } from '@dfinity/agent';
+import { browser } from '$app/environment';
+import type { ContentData } from '../../declarations/rp/rp.did';
+import { queryExclusiveContent } from '$lib/api/queryExclusiveContent.api';
+
+let contentDataStore: Writable<ContentData[] | undefined> | undefined = undefined;
+export const getExclusiveContentData = (
+  identity: Identity | undefined | null
+): Writable<ContentData[] | undefined> => {
+  if (!contentDataStore) {
+    contentDataStore = writable<ContentData[] | undefined>(undefined, (_set, update) => {
+      if (browser) {
+        queryExclusiveContent({ identity: identity ?? new AnonymousIdentity() }).then(
+          ({ content_items }) => {
+            update(() => content_items);
+          }
+        );
+      }
+    });
+  }
+  return contentDataStore;
+};
+
+export const getExclusiveContentDataSortedByCreatedTimestamp = (
+  identity: Identity | null | undefined
+): Readable<ContentData[]> =>
+  derived(getExclusiveContentData(identity), ($contentData) => {
+    if (!$contentData) return [];
+    return $contentData.sort((a, b) => Number(b.created_timestamp_ns - a.created_timestamp_ns));
+  });

--- a/rp/frontend/src/lib/stores/images.store.ts
+++ b/rp/frontend/src/lib/stores/images.store.ts
@@ -4,22 +4,18 @@ import { browser } from '$app/environment';
 import { queryImages } from '$lib/api/queryImages.api';
 import type { ImageData } from '../../declarations/rp/rp.did';
 
-const imagesStores: Record<string, Writable<ImageData[] | undefined>> = {};
+let imagesStore: Writable<ImageData[] | undefined> | undefined = undefined;
 export const getImagesStore = (
   identity: Identity | undefined | null
 ): Writable<ImageData[] | undefined> => {
-  const identityPrincipal = identity?.getPrincipal().toText() ?? 'no-authenticated-identity';
-  if (!imagesStores[identityPrincipal]) {
-    imagesStores[identityPrincipal] = writable<ImageData[] | undefined>(
-      undefined,
-      (_set, update) => {
-        if (browser) {
-          queryImages({ identity: identity ?? new AnonymousIdentity() }).then(({ images }) => {
-            update(() => images);
-          });
-        }
+  if (!imagesStore) {
+    imagesStore = writable<ImageData[] | undefined>(undefined, (_set, update) => {
+      if (browser) {
+        queryImages({ identity: identity ?? new AnonymousIdentity() }).then(({ images }) => {
+          update(() => images);
+        });
       }
-    );
+    });
   }
-  return imagesStores[identityPrincipal];
+  return imagesStore;
 };

--- a/rp/frontend/src/lib/stores/issuers.store.ts
+++ b/rp/frontend/src/lib/stores/issuers.store.ts
@@ -4,22 +4,18 @@ import { queryGroups } from '$lib/api/queryGroups.api';
 import { browser } from '$app/environment';
 import type { PublicGroupData } from '../../declarations/meta_issuer/meta_issuer.did';
 
-const issuers: Record<string, Writable<PublicGroupData[] | undefined>> = {};
+let issuersStore: Writable<PublicGroupData[] | undefined> | undefined = undefined;
 export const getIssuersStore = (
   identity: Identity | undefined | null
 ): Writable<PublicGroupData[] | undefined> => {
-  const identityPrincipal = identity?.getPrincipal().toText() ?? 'no-authenticated-identity';
-  if (!issuers[identityPrincipal]) {
-    issuers[identityPrincipal] = writable<PublicGroupData[] | undefined>(
-      undefined,
-      (_set, update) => {
-        if (browser) {
-          queryGroups({ identity: identity ?? new AnonymousIdentity() }).then((groups) => {
-            update(() => groups);
-          });
-        }
+  if (!issuersStore) {
+    issuersStore = writable<PublicGroupData[] | undefined>(undefined, (_set, update) => {
+      if (browser) {
+        queryGroups({ identity: identity ?? new AnonymousIdentity() }).then((groups) => {
+          update(() => groups);
+        });
       }
-    );
+    });
   }
-  return issuers[identityPrincipal];
+  return issuersStore;
 };

--- a/rp/frontend/src/lib/utils/date.utils.ts
+++ b/rp/frontend/src/lib/utils/date.utils.ts
@@ -1,0 +1,24 @@
+const secondsToTime = (seconds: number): string => {
+  const options: Intl.DateTimeFormatOptions = {
+    timeStyle: 'short',
+  };
+  const milliseconds = seconds * 1000;
+  // We only support english for now.
+  return new Date(milliseconds).toLocaleTimeString('en', options);
+};
+
+const secondsToDate = (seconds: number): string => {
+  const options: Intl.DateTimeFormatOptions = {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  };
+  const milliseconds = seconds * 1000;
+  // We only support english for now.
+  return new Date(milliseconds).toLocaleDateString('en', options);
+};
+
+export const nanoSecondsToDateTime = (nanoSeconds: bigint): string => {
+  const seconds = Number(nanoSeconds / BigInt(1e9));
+  return `${secondsToDate(seconds)} ${secondsToTime(seconds)}`;
+};

--- a/rp/frontend/src/routes/+page.svelte
+++ b/rp/frontend/src/routes/+page.svelte
@@ -1,17 +1,12 @@
 <script lang="ts">
   import ImagesGrid from '$lib/components/ImagesGrid.svelte';
+  import type { Readable } from 'svelte/store';
+  import type { ContentData } from '../declarations/rp/rp.did';
+  import { getExclusiveContentDataSortedByCreatedTimestamp } from '$lib/stores/content-data.store';
+  import { authStore } from '$lib/stores/auth.store';
 
-  const contentImages: { imageUrl: string; issuerName: string }[] = [
-    'https://images.unsplash.com/photo-1617296538902-887900d9b592?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzExMDB8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-    'https://images.unsplash.com/photo-1597077962467-be16edcc6a43?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2MzZ8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-    'https://images.unsplash.com/photo-1553184570-557b84a3a308?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2NTF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-    'https://images.unsplash.com/photo-1509130446053-899ae7358ce6?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2NjF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-    'https://images.unsplash.com/photo-1620005839871-7ac4aed5ddbc?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2NzN8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-    'https://images.unsplash.com/photo-1597531072931-8fceba101e4e?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY2OTB8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-    'https://images.unsplash.com/photo-1510111652602-195fc654aa83?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY0Nzl8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-    'https://images.unsplash.com/photo-1612145342709-eadb6e22acca?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY3MDh8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-    'https://images.unsplash.com/photo-1597077917598-97ca3922a317?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzY3MjF8&amp;ixlib=rb-4.0.3&amp;w=300&amp;h=300&amp;auto=format&amp;fit=crop',
-  ].map((imageUrl, i) => ({ issuerName: `Photo Gallery with a very long name ${i}`, imageUrl }));
+  let contentDataStore: Readable<ContentData[]>;
+  $: contentDataStore = getExclusiveContentDataSortedByCreatedTimestamp($authStore.identity);
 </script>
 
 <h1 class="h1 text-center">View and Share Content</h1>
@@ -19,4 +14,4 @@
   This is an example of a Relying Party. You can view an image if you hold the particular credential
   required to access the image.
 </p>
-<ImagesGrid images={contentImages} />
+<ImagesGrid images={$contentDataStore} />

--- a/rp/frontend/src/routes/share/+page.svelte
+++ b/rp/frontend/src/routes/share/+page.svelte
@@ -73,7 +73,7 @@
     <label for="credentials">
       <h5 class="h5">With whom would you like to share this?</h5>
     </label>
-    <select bind:value={selectedIssuerName} id="credentials" class="select">
+    <select bind:value={selectedIssuerName} id="credentials" class="select px-4">
       <option value="" disabled selected>Select an issuer</option>
       {#each $issuersStore ?? [] as issuer}
         <option value={issuer.group_name} id={issuer.group_name}>


### PR DESCRIPTION
Main motivation is to move the mocks used in home to the api layer so that the functionality of the page closer to what it will be with backend.

In this PR:
* New api function queryExclusiveContent.
* ImagesGrid expects backend data ContentData and passes issuer data to modal.
* ViewExclusiveContentModal uses data in `meta`.
* New content-data store.
* Refactor imagesStore and issuerStore to not cache by identity because there is nothing specific to the identity to cache for.
* New date util `nanoSecondsToDateTime`.
* Home page uses new content-data store to read data and trigger the api.
* Improve horizontal padding of the select.