### PR TITLE
Add an initial RP-BE implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,6 +2765,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "relying_party"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "asset_util",
+ "candid",
+ "candid_parser",
+ "canister_sig_util",
+ "canister_tests",
+ "hex",
+ "ic-cdk",
+ "ic-cdk-macros",
+ "ic-certification 2.2.0",
+ "ic-http-certification",
+ "ic-response-verification",
+ "ic-stable-structures 0.6.3",
+ "ic-test-state-machine-client",
+ "include_dir",
+ "internet_identity_interface",
+ "lazy_static",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "vc_util",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "issuer",
+    "rp",
 ]
 resolver = "2"

--- a/rp/Cargo.toml
+++ b/rp/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "relying_party"
+description = "A relying party for VC playground"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# IC/II dependencies
+canister_sig_util = { git="https://github.com/dfinity/internet-identity", rev="facc954481eaf79c70d1182d128773254a5cfb81" }
+internet_identity_interface = { git="https://github.com/dfinity/internet-identity", rev="facc954481eaf79c70d1182d128773254a5cfb81" }
+vc_util = { git="https://github.com/dfinity/internet-identity", rev="facc954481eaf79c70d1182d128773254a5cfb81" }
+asset_util = { git="https://github.com/dfinity/internet-identity", rev="facc954481eaf79c70d1182d128773254a5cfb81" }
+candid = "0.10"
+ic-cdk = "0.12"
+ic-cdk-macros = "0.8"
+ic-certification = "2.2"
+ic-stable-structures = "0.6"
+
+# other dependencies
+hex = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_bytes = "0.11"
+serde_cbor = "0.11"
+serde_json = "1"
+sha2 = "^0.10" # set bound to match ic-certified-map bound
+lazy_static = "1.4"
+include_dir = "0.7"
+
+[dev-dependencies]
+assert_matches = "1.5.0"
+candid_parser = "0.1"
+ic-http-certification = "2.2"
+ic-test-state-machine-client = "3"
+ic-response-verification = "2.2"
+canister_tests = { git="https://github.com/dfinity/internet-identity", rev="facc954481eaf79c70d1182d128773254a5cfb81" }

--- a/rp/build.sh
+++ b/rp/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Make sure we always run from the issuer root
+RP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$RP_DIR"
+
+
+# Build the canister
+cargo build --release --target wasm32-unknown-unknown --manifest-path ./Cargo.toml -j1
+ic-wasm "../target/wasm32-unknown-unknown/release/relying_party.wasm" -o "./relying_party.wasm" shrink
+ic-wasm relying_party.wasm -o relying_party.wasm metadata candid:service -f rp.did -v public
+# indicate support for certificate version 1 and 2 in the canister metadata
+ic-wasm relying_party.wasm -o relying_party.wasm metadata supported_certificate_versions -d "1,2" -v public
+gzip --no-name --force "relying_party.wasm"
+mv relying_party.wasm.gz ../

--- a/rp/rp.did
+++ b/rp/rp.did
@@ -29,6 +29,7 @@ type ListExclusiveContentRequest = record {
 };
 
 type ContentData = record {
+    content_name: text;
     owner: principal;
     created_timestamp_ns: TimestampNs;
     url: text;
@@ -41,6 +42,7 @@ type ExclusiveContentList = record {
 
 
 type AddExclusiveContentRequest = record {
+    content_name: text;
     url: text;
     credential_group_name: text;
 };
@@ -67,7 +69,6 @@ type HttpResponse = record {
 };
 
 type RpConfig = record {};
-
 
 service: (opt RpConfig) -> {
     /// API for creating/accessing exclusive content.

--- a/rp/src/lib.rs
+++ b/rp/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod rp_api;

--- a/rp/src/main.rs
+++ b/rp/src/main.rs
@@ -1,0 +1,311 @@
+use candid::{candid_method, CandidType, Deserialize, Principal};
+use ic_cdk::api::{caller, set_certified_data, time};
+use ic_cdk_macros::{init, query, update};
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::storable::{Bound, Storable};
+use ic_stable_structures::{DefaultMemoryImpl, RestrictedMemory, StableBTreeMap, StableCell};
+use include_dir::{include_dir, Dir};
+use relying_party::rp_api::{
+    AddExclusiveContentRequest, ContentData, ContentError, ExclusiveContentList, HttpRequest,
+    HttpResponse, ImageData, ImagesList, ListExclusiveContentRequest, ListImagesRequest,
+    UploadImagesRequest,
+};
+use serde_bytes::ByteBuf;
+use std::borrow::Cow;
+use std::cell::RefCell;
+
+use asset_util::{collect_assets, CertifiedAssets};
+use ic_cdk_macros::post_upgrade;
+
+/// We use restricted memory in order to ensure the separation between non-managed config memory (first page)
+/// and the managed memory for potential other data of the canister.
+type Memory = RestrictedMemory<DefaultMemoryImpl>;
+type ConfigCell = StableCell<RpConfig, Memory>;
+type ImagesMap = StableBTreeMap<String, ImageRecord, VirtualMemory<Memory>>;
+type ExclusiveContentMap = StableBTreeMap<String, ExclusiveContentRecord, VirtualMemory<Memory>>;
+
+const IMAGES_MEMORY_ID: MemoryId = MemoryId::new(0u8);
+const EXCLUSIVE_CONTENT_MEMORY_ID: MemoryId = MemoryId::new(1u8);
+
+// Internal container of per-image data.
+#[derive(CandidType, Clone, Deserialize)]
+struct ImageRecord {
+    pub bytes: Vec<u8>,
+}
+
+#[derive(CandidType, Clone, Deserialize)]
+struct ExclusiveContentRecord {
+    owner: Principal,
+    created_timestamp_ns: u64,
+    url: String,
+    credential_group_name: String,
+}
+
+impl Storable for ImageRecord {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(candid::encode_one(self).expect("failed to encode ImageRecord"))
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).expect("failed to decode ImageRecord")
+    }
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+impl Storable for ExclusiveContentRecord {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(candid::encode_one(self).expect("failed to encode ExclusiveContentRecord"))
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).expect("failed to decode ExclusiveContentRecord")
+    }
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+thread_local! {
+    /// Stable structures
+    // Static configuration of the canister set by init() or post_upgrade().
+    static CONFIG: RefCell<ConfigCell> = RefCell::new(ConfigCell::init(config_memory(), RpConfig::default()).expect("failed to initialize stable cell"));
+
+    static MEMORY_MANAGER: RefCell<MemoryManager<Memory>> =
+        RefCell::new(MemoryManager::init(managed_memory()));
+    static IMAGES : RefCell<ImagesMap> = RefCell::new(
+      StableBTreeMap::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(IMAGES_MEMORY_ID)),
+    ));
+
+    static EXCLUSIVE_CONTENT : RefCell<ExclusiveContentMap> = RefCell::new(
+      StableBTreeMap::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(EXCLUSIVE_CONTENT_MEMORY_ID)),
+    ));
+    /// Non-stable structures
+    // Assets for the management app
+    static ASSETS: RefCell<CertifiedAssets> = RefCell::new(CertifiedAssets::default());
+}
+
+/// Reserve the first stable memory page for the configuration stable cell.
+fn config_memory() -> Memory {
+    RestrictedMemory::new(DefaultMemoryImpl::default(), 0..1)
+}
+
+/// All the stable memory after the first page is managed by MemoryManager
+fn managed_memory() -> Memory {
+    RestrictedMemory::new(
+        DefaultMemoryImpl::default(),
+        1..ic_stable_structures::MAX_PAGES,
+    )
+}
+
+#[derive(CandidType, Deserialize)]
+struct RpConfig {}
+
+impl Storable for RpConfig {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(candid::encode_one(self).expect("failed to encode RpConfig"))
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).expect("failed to decode RpConfig")
+    }
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+impl Default for RpConfig {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+#[init]
+#[candid_method(init)]
+fn init(init_arg: Option<RpConfig>) {
+    if let Some(config) = init_arg {
+        apply_config(config);
+    };
+    init_assets();
+}
+
+#[post_upgrade]
+fn post_upgrade(init_arg: Option<RpConfig>) {
+    init(init_arg);
+}
+
+fn image_name_to_url(image_name: &str) -> String {
+    format!("images/{}", image_name)
+}
+
+/// API for obtaining info about images and exclusive content.
+#[query]
+#[candid_method(query)]
+fn list_images(_req: ListImagesRequest) -> Result<ImagesList, ContentError> {
+    IMAGES.with_borrow(|images| {
+        let mut list = vec![];
+        for (image_name, _record) in images.iter() {
+            list.push(ImageData {
+                url: image_name_to_url(&image_name),
+            })
+        }
+        Ok(ImagesList { images: list })
+    })
+}
+
+#[query]
+#[candid_method(query)]
+fn list_exclusive_content(
+    _req: ListExclusiveContentRequest,
+) -> Result<ExclusiveContentList, ContentError> {
+    EXCLUSIVE_CONTENT.with_borrow(|content| {
+        let mut list = vec![];
+        for (content_name, record) in content.iter() {
+            list.push(ContentData {
+                content_name,
+                owner: record.owner,
+                url: record.url,
+                created_timestamp_ns: record.created_timestamp_ns,
+                credential_group_name: record.credential_group_name,
+            })
+        }
+        Ok(ExclusiveContentList {
+            content_items: list,
+        })
+    })
+}
+
+#[update]
+#[candid_method]
+fn add_exclusive_content(req: AddExclusiveContentRequest) -> Result<ContentData, ContentError> {
+    EXCLUSIVE_CONTENT.with_borrow_mut(|content| {
+        let data = ContentData {
+            content_name: req.content_name,
+            owner: caller(),
+            url: req.url,
+            created_timestamp_ns: time(),
+            credential_group_name: req.credential_group_name,
+        };
+
+        content.insert(
+            data.content_name.clone(),
+            ExclusiveContentRecord {
+                owner: data.owner,
+                created_timestamp_ns: data.created_timestamp_ns,
+                url: data.url.clone(),
+                credential_group_name: data.credential_group_name.clone(),
+            },
+        );
+        Ok(data)
+    })
+}
+
+// TODO: restrict or remove `configure()`.
+#[update]
+#[candid_method]
+fn configure(config: RpConfig) {
+    apply_config(config);
+}
+
+fn apply_config(config: RpConfig) {
+    CONFIG
+        .with_borrow_mut(|config_cell| config_cell.set(config))
+        .expect("failed to apply RP config");
+}
+
+#[update]
+#[candid_method]
+async fn upload_images(_req: UploadImagesRequest) -> Result<ImagesList, ContentError> {
+    IMAGES.with_borrow_mut(|images| {
+        // TODO: upload the images and update the assets
+        let mut list = vec![];
+        for (image_name, _record) in images.iter() {
+            list.push(ImageData {
+                url: image_name_to_url(&image_name),
+            })
+        }
+        update_root_hash();
+        Ok(ImagesList { images: list })
+    })
+}
+
+fn update_root_hash() {
+    ASSETS.with_borrow(|assets| {
+        set_certified_data(&assets.root_hash());
+    })
+}
+
+#[query]
+#[candid_method(query)]
+pub fn http_request(req: HttpRequest) -> HttpResponse {
+    let parts: Vec<&str> = req.url.split('?').collect();
+    let path = parts[0];
+    let maybe_asset = ASSETS
+        .with_borrow(|assets| assets.get_certified_asset(path, req.certificate_version, None));
+
+    let mut headers = static_headers();
+    match maybe_asset {
+        Some(asset) => {
+            headers.extend(asset.headers);
+            HttpResponse {
+                status_code: 200,
+                body: ByteBuf::from(asset.content),
+                headers,
+            }
+        }
+        None => HttpResponse {
+            status_code: 404,
+            headers,
+            body: ByteBuf::from(format!("Asset {} not found.", path)),
+        },
+    }
+}
+
+fn static_headers() -> Vec<(String, String)> {
+    vec![("Access-Control-Allow-Origin".to_string(), "*".to_string())]
+}
+
+fn main() {}
+
+// Order dependent: do not move above any function annotated with #[candid_method]!
+candid::export_service!();
+
+// Assets
+static ASSET_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/frontend/dist");
+pub fn init_assets() {
+    ASSETS.with_borrow_mut(|assets| {
+        *assets = CertifiedAssets::certify_assets(
+            collect_assets(&ASSET_DIR, Some(fixup_html)),
+            &static_headers(),
+        );
+    });
+    update_root_hash()
+}
+
+fn fixup_html(html: &str) -> String {
+    let canister_id = ic_cdk::api::id();
+
+    // the string we are replacing here is part of the astro main Layout
+    html.replace(
+        r#"data-app"#,
+        &format!(r#"data-app data-canister-id="{canister_id}""#).to_string(),
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use crate::__export_service;
+    use candid_parser::utils::{service_equal, CandidSource};
+    use std::path::Path;
+
+    /// Checks candid interface type equality by making sure that the service in the did file is
+    /// equal to the generated interface.
+    #[test]
+    fn check_candid_interface_compatibility() {
+        let canister_interface = __export_service();
+        service_equal(
+            CandidSource::Text(&canister_interface),
+            CandidSource::File(Path::new("rp.did")),
+        )
+        .unwrap_or_else(|e| {
+            panic!(
+                "the canister code interface is not equal to the did file: {:?}",
+                e
+            )
+        });
+    }
+}

--- a/rp/src/rp_api.rs
+++ b/rp/src/rp_api.rs
@@ -1,0 +1,73 @@
+use candid::{CandidType, Deserialize, Principal};
+use serde_bytes::ByteBuf;
+
+/// Types for requesting a list of available images.
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ListImagesRequest {}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct UploadImagesRequest {}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ImageData {
+    pub url: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ImagesList {
+    pub images: Vec<ImageData>,
+}
+
+/// Types for requesting or adding exclusive content items.
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ListExclusiveContentRequest {
+    pub owned_by: Option<Principal>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ContentData {
+    pub owner: Principal,
+    pub content_name: String,
+    pub created_timestamp_ns: u64,
+    pub url: String,
+    pub credential_group_name: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ExclusiveContentList {
+    pub content_items: Vec<ContentData>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct AddExclusiveContentRequest {
+    pub content_name: String,
+    pub url: String,
+    pub credential_group_name: String,
+}
+
+// Types related to HTTP-endpoint.
+pub type HeaderField = (String, String);
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpRequest {
+    pub method: String,
+    pub url: String,
+    pub headers: Vec<HeaderField>,
+    pub body: ByteBuf,
+    pub certificate_version: Option<u16>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpResponse {
+    pub status_code: u16,
+    pub headers: Vec<HeaderField>,
+    pub body: ByteBuf,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum ContentError {
+    NotAuthorized(String),
+    AlreadyExists(String),
+    NotFound(String),
+    Internal(String),
+}

--- a/rp/tests/manage_content.rs
+++ b/rp/tests/manage_content.rs
@@ -1,0 +1,95 @@
+//! Tests related to group management API.
+use canister_tests::framework::{env, principal_1, principal_2, test_principal};
+use relying_party::rp_api::ContentData;
+use std::collections::HashMap;
+
+#[allow(dead_code)]
+mod util;
+use crate::util::{do_add_exclusive_content, do_list_exclusive_content, install_rp};
+
+#[test]
+fn should_add_exclusive_content() {
+    let env = env();
+    let canister_id = install_rp(&env, None);
+    let caller = principal_1();
+
+    let content_name = "Some content name";
+    let group_name = "Some group name";
+    let url = "http://example.com";
+    let content_data =
+        do_add_exclusive_content(content_name, url, group_name, caller, &env, canister_id);
+    let expected_content_data = ContentData {
+        owner: caller,
+        content_name: content_name.to_string(),
+        created_timestamp_ns: content_data.created_timestamp_ns,
+        url: url.to_string(),
+        credential_group_name: group_name.to_string(),
+    };
+    assert_eq!(content_data, expected_content_data);
+}
+
+#[test]
+fn should_list_exclusive_content() {
+    let env = env();
+    let canister_id = install_rp(&env, None);
+    let caller = principal_1();
+
+    let content_name = "Some content name";
+    let group_name = "Some group name";
+    let url = "http://example.com";
+    let content_data =
+        do_add_exclusive_content(content_name, url, group_name, caller, &env, canister_id);
+    let content_list = do_list_exclusive_content(&env, None, canister_id);
+    let expected_content_data = ContentData {
+        owner: caller,
+        content_name: content_name.to_string(),
+        created_timestamp_ns: content_data.created_timestamp_ns,
+        url: url.to_string(),
+        credential_group_name: group_name.to_string(),
+    };
+    assert_eq!(content_list.content_items.len(), 1);
+    assert_eq!(content_list.content_items[0], expected_content_data);
+}
+
+#[test]
+fn should_list_exclusive_content_multiple_items() {
+    let env = env();
+    let canister_id = install_rp(&env, None);
+    let caller = [principal_1(), principal_2(), test_principal(42)];
+
+    let content_name = [
+        "Some content name 1",
+        "content name 2",
+        "another content name",
+    ];
+    let group_name = ["group name 1", "other group name", "yet another group"];
+    let url = ["http://example_1.com", "other.url", "another url"];
+    let mut expected_list = HashMap::new();
+    for i in 0..3 {
+        let content_data = do_add_exclusive_content(
+            content_name[i],
+            url[i],
+            group_name[i],
+            caller[i],
+            &env,
+            canister_id,
+        );
+        let expected_content_data = ContentData {
+            owner: caller[i],
+            content_name: content_name[i].to_string(),
+            created_timestamp_ns: content_data.created_timestamp_ns,
+            url: url[i].to_string(),
+            credential_group_name: group_name[i].to_string(),
+        };
+        expected_list.insert(content_name[i].to_string(), expected_content_data);
+    }
+    let content_list = do_list_exclusive_content(&env, None, canister_id);
+
+    assert_eq!(content_list.content_items.len(), content_name.len());
+    for item in content_list.content_items {
+        let expected = expected_list
+            .remove_entry(&item.content_name)
+            .expect("Unexpected item");
+        assert_eq!(expected.1, item);
+    }
+}

--- a/rp/tests/util/mod.rs
+++ b/rp/tests/util/mod.rs
@@ -1,0 +1,135 @@
+use candid::{CandidType, Deserialize, Principal};
+use canister_tests::framework::get_wasm_path;
+use ic_cdk::api::management_canister::main::CanisterId;
+use ic_test_state_machine_client::{call_candid, call_candid_as, CallError, StateMachine};
+use lazy_static::lazy_static;
+use relying_party::rp_api::{
+    AddExclusiveContentRequest, ContentData, ContentError, ExclusiveContentList, ImagesList,
+    ListExclusiveContentRequest, ListImagesRequest,
+};
+use std::path::PathBuf;
+
+lazy_static! {
+    /// Gzipped Wasm module for the current Early Adopter Issuer build, i.e. the one we're testing
+    pub static ref RELYING_PARTY_WASM: Vec<u8> = {
+        let def_path = PathBuf::from("./../").join("relying_party.wasm.gz");
+        let err = format!("
+        Could not find Early Adopter Issuer Wasm module for current build.
+        I will look for it at {:?} (note that I run from {:?}).
+        You can build the Wasm by running ./build.sh
+        ", &def_path,
+            &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_|
+                "an unknown directory".to_string()));
+                get_wasm_path("RELYING_PARTY_WASM".to_string(), &def_path).expect(&err)
+
+    };
+
+}
+
+// Setup helpers.
+#[derive(CandidType, Clone, Deserialize)]
+pub struct RpConfig {}
+
+pub fn install_canister(env: &StateMachine, wasm: Vec<u8>) -> CanisterId {
+    let canister_id = env.create_canister(None);
+    let arg = candid::encode_one("()").expect("error encoding empty arg as candid");
+    env.install_canister(canister_id, wasm, arg, None);
+    canister_id
+}
+
+pub fn install_rp(env: &StateMachine, maybe_init: Option<RpConfig>) -> CanisterId {
+    let canister_id = env.create_canister(None);
+    let arg = match maybe_init {
+        Some(init) => {
+            candid::encode_one(Some(init)).expect("error encoding issuer init arg as candid")
+        }
+        None => candid::encode_one("()").expect("error encoding empty arg as candid"),
+    };
+    env.install_canister(canister_id, RELYING_PARTY_WASM.clone(), arg, None);
+    canister_id
+}
+
+// API helpers.
+pub fn do_add_exclusive_content(
+    content_name: &str,
+    url: &str,
+    credential_group_name: &str,
+    caller: Principal,
+    env: &StateMachine,
+    canister_id: Principal,
+) -> ContentData {
+    api::add_exclusive_content(
+        env,
+        canister_id,
+        caller,
+        AddExclusiveContentRequest {
+            content_name: content_name.to_string(),
+            url: url.to_string(),
+            credential_group_name: credential_group_name.to_string(),
+        },
+    )
+    .expect("API call failed")
+    .expect("Failed add_exclusive_content")
+}
+
+pub fn do_list_images(env: &StateMachine, canister_id: Principal) -> ImagesList {
+    api::list_images(env, canister_id, &ListImagesRequest {})
+        .expect("API call failed")
+        .expect("Failed list_images")
+}
+
+pub fn do_list_exclusive_content(
+    env: &StateMachine,
+    maybe_owner: Option<Principal>,
+    canister_id: Principal,
+) -> ExclusiveContentList {
+    api::list_exclusive_content(
+        env,
+        canister_id,
+        &ListExclusiveContentRequest {
+            owned_by: maybe_owner,
+        },
+    )
+    .expect("API call failed")
+    .expect("Failed list_exclusive_content")
+}
+
+/// Relying party API.
+pub mod api {
+    use super::*;
+    use ic_test_state_machine_client::query_candid;
+    use relying_party::rp_api::{AddExclusiveContentRequest, ContentData};
+
+    pub fn configure(
+        env: &StateMachine,
+        canister_id: CanisterId,
+        config: &RpConfig,
+    ) -> Result<(), CallError> {
+        call_candid(env, canister_id, "configure", (config,))
+    }
+
+    pub fn list_images(
+        env: &StateMachine,
+        canister_id: CanisterId,
+        req: &ListImagesRequest,
+    ) -> Result<Result<ImagesList, ContentError>, CallError> {
+        query_candid(env, canister_id, "list_images", (req,)).map(|(x,)| x)
+    }
+
+    pub fn list_exclusive_content(
+        env: &StateMachine,
+        canister_id: CanisterId,
+        req: &ListExclusiveContentRequest,
+    ) -> Result<Result<ExclusiveContentList, ContentError>, CallError> {
+        query_candid(env, canister_id, "list_exclusive_content", (req,)).map(|(x,)| x)
+    }
+
+    pub fn add_exclusive_content(
+        env: &StateMachine,
+        canister_id: CanisterId,
+        sender: Principal,
+        req: AddExclusiveContentRequest,
+    ) -> Result<Result<ContentData, ContentError>, CallError> {
+        call_candid_as(env, canister_id, sender, "add_exclusive_content", (req,)).map(|(x,)| x)
+    }
+}


### PR DESCRIPTION
This is an initial relying party BE implementation.  It is without image uploading/serving functionality yet, which will be added in a follow-up PR.