### PR TITLE
Show images after getting credential

### DIFF
--- a/rp/frontend/src/lib/components/ImagesGrid.svelte
+++ b/rp/frontend/src/lib/components/ImagesGrid.svelte
@@ -4,14 +4,14 @@
   import { authStore } from '$lib/stores/auth.store';
   import { nonNullish } from '$lib/utils/non-nullish';
   import { login } from '$lib/services/auth.services';
-  import type { ContentData } from '../../declarations/rp/rp.did';
   import { nanoSecondsToDateTime } from '$lib/utils/date.utils';
+  import type { VisibleContentData } from '$lib/stores/content-data-visible.store';
 
-  export let images: ContentData[] = [];
+  export let images: VisibleContentData[] = [];
 
   const modalStore = getModalStore();
 
-  const openImageFactory = (content: ContentData) => () => {
+  const openImageFactory = (content: VisibleContentData) => () => {
     if (nonNullish($authStore.identity)) {
       const modal: ModalSettings = {
         type: 'component',
@@ -23,23 +23,47 @@
       login();
     }
   };
+
+  const visibleImageGradient = `
+    background-image: linear-gradient(
+      to bottom, 
+      rgba(0,0,0,0.8) 0%, 
+      rgba(0,0,0,0) 3rem,
+      rgba(0,0,0,0) calc(100% - 3rem), /* Transparent middle */
+      rgba(0,0,0,0.8) 100%);
+  `;
 </script>
 
-<section class="grid grid-cols-2 md:grid-cols-3 gap-4">
+<section class="grid grid-cols-2 md:grid-cols-3 gap-4 text-surface-50">
   {#each images as image}
-    <!-- TODO: Show image if the user has the credential -->
-    <div class="relative">
-      <div class="absolute -top-0 -left-0 w-full flex flex-col items-center py-2 px-2 h-full">
-        <h5 class="h5 truncate w-full">{image.credential_group_name}</h5>
-        <div class="flex-1 flex justify-center items-center">
-          <Button variant="ghost-primary" on:click={openImageFactory(image)}>View</Button>
+    {#if image.visible}
+      <div class="relative overflow-hidden">
+        <div
+          class="rounded-lg absolute -top-0 -left-0 w-full flex flex-col justify-between py-2 px-2 h-full"
+          style={visibleImageGradient}
+        >
+          <h5 class="h5 truncate w-full">{image.credential_group_name}</h5>
+          <p class="text-sm self-start">{nanoSecondsToDateTime(image.created_timestamp_ns)}</p>
         </div>
-        <p class="text-sm self-start">{nanoSecondsToDateTime(image.created_timestamp_ns)}</p>
+        <div
+          class="h-auto max-w-full rounded-lg aspect-square"
+          style="background-image: url({image.url}); background-size: cover; background-position: center;"
+        />
       </div>
-      <div
-        class="h-auto max-w-full rounded-lg aspect-square bg-gradient-to-b from-primary-500 to-secondary-500"
-      />
-    </div>
+    {:else}
+      <div class="relative">
+        <div class="absolute -top-0 -left-0 w-full flex flex-col items-center py-2 px-2 h-full">
+          <h5 class="h5 truncate w-full">{image.credential_group_name}</h5>
+          <div class="flex-1 flex justify-center items-center">
+            <Button variant="ghost-primary" on:click={openImageFactory(image)}>View</Button>
+          </div>
+          <p class="text-sm self-start">{nanoSecondsToDateTime(image.created_timestamp_ns)}</p>
+        </div>
+        <div
+          class="h-auto max-w-full rounded-lg aspect-square bg-gradient-to-b from-primary-500 to-secondary-500"
+        />
+      </div>
+    {/if}
   {/each}
 </section>
 

--- a/rp/frontend/src/lib/components/Modal.svelte
+++ b/rp/frontend/src/lib/components/Modal.svelte
@@ -1,10 +1,12 @@
 <div
-  class="modal block overflow-y-auto bg-surface-100-800-token w-modal h-auto p-4 space-y-4 rounded-container-token shadow-xl"
+  class="modal block overflow-y-auto bg-surface-100-800-token w-modal h-auto min-h-80 p-4 rounded-container-token shadow-xl flex flex-col gap-4"
   role="dialog"
   aria-modal="true"
 >
   <header class="modal-header text-2xl font-bold"><slot name="header" /></header>
-  <slot />
+  <div class="flex-1 flex flex-col">
+    <slot />
+  </div>
   <div class="modal-footer flex justify-end space-x-2">
     <slot name="footer" />
   </div>

--- a/rp/frontend/src/lib/services/auth.services.ts
+++ b/rp/frontend/src/lib/services/auth.services.ts
@@ -1,5 +1,6 @@
 import { goto } from '$app/navigation';
 import { authStore } from '$lib/stores/auth.store';
+import { credentialsStore } from '$lib/stores/credentials.store';
 import { popupCenter } from '$lib/utils/login-popup.utils';
 import { AuthClient } from '@dfinity/auth-client';
 
@@ -67,6 +68,7 @@ export const logout = async () => {
     // TODO: Handle error
   } finally {
     // Always clear the cached client and the identity store.
+    credentialsStore.reset();
     cachedClient = undefined;
     authStore.set({ identity: null });
     goto('/');

--- a/rp/frontend/src/lib/services/load-credential.services.ts
+++ b/rp/frontend/src/lib/services/load-credential.services.ts
@@ -1,3 +1,4 @@
+import { credentialsStore } from '$lib/stores/credentials.store';
 import { isNullish } from '$lib/utils/is-nullish.utils';
 import type { Identity } from '@dfinity/agent';
 import { decodeJwt } from 'jose';
@@ -8,45 +9,46 @@ const ISSUER_CANISTER_ID = import.meta.env.VITE_ISSUER_CANISTER_ID;
 
 let iiWindow: Window | null = null;
 
-export const getCredential = async ({
+export const loadCredential = async ({
   groupName,
   identity,
 }: {
   groupName: string;
   identity: Identity | undefined | null;
-}): Promise<string | null> => {
+}): Promise<null> => {
   if (isNullish(identity)) {
     return null;
   }
-  return new Promise<string | null>((resolve) => {
+  return new Promise<null>((resolve) => {
     const handleFlowFinished = (evnt: MessageEvent) => {
       try {
-        console.log('Flow finished', evnt.data);
         // Make the presentation presentable
         const verifiablePresentation = evnt.data?.result?.verifiablePresentation;
         if (verifiablePresentation === undefined) {
           console.error('No verifiable presentation found');
-          resolve(null);
-        }
+          credentialsStore.setCredential({
+            groupName,
+            hasCredential: false,
+          });
+        } else {
+          /* eslint-disable-next-line */
+          decodeJwt(verifiablePresentation) as any;
+          // TODO: Validate the credential
 
-        /* eslint-disable-next-line */
-        const ver = decodeJwt(verifiablePresentation) as any;
-        const creds = ver.vp.verifiableCredential;
-        const [alias, credential] = creds.map((cred: string) =>
-          JSON.stringify(decodeJwt(cred), null, 2)
-        );
-        console.log('Alias:', alias);
-        console.log('Credential:', credential);
-        const resultElement = document.getElementById('vc-result');
-        if (resultElement) {
-          resultElement.innerText = `Alias: ${alias}\nCredential: ${credential}`;
+          credentialsStore.setCredential({
+            groupName,
+            hasCredential: true,
+          });
         }
       } catch (error) {
-        resolve(null);
+        credentialsStore.setCredential({
+          groupName,
+          hasCredential: false,
+        });
       } finally {
         iiWindow?.close();
         window.removeEventListener('message', handleFlowFinished);
-        resolve('approved');
+        resolve(null);
       }
     };
     const handleFlowReady = (evnt: MessageEvent) => {

--- a/rp/frontend/src/lib/stores/content-data-visible.store.ts
+++ b/rp/frontend/src/lib/stores/content-data-visible.store.ts
@@ -1,0 +1,23 @@
+import { derived, type Readable } from 'svelte/store';
+import type { ContentData } from '../../declarations/rp/rp.did';
+import { getExclusiveContentDataSortedByCreatedTimestamp } from './content-data.store';
+import type { Identity } from '@dfinity/agent';
+import { credentialsStore } from './credentials.store';
+
+export type VisibleContentData = ContentData & {
+  visible: boolean;
+};
+
+export const getVisibleContentData = (
+  identity: Identity | null | undefined
+): Readable<VisibleContentData[]> =>
+  derived(
+    [getExclusiveContentDataSortedByCreatedTimestamp(identity), credentialsStore],
+    ([$contentData, credentials]) => {
+      if (!$contentData) return [];
+      return $contentData.map((contentData) => ({
+        ...contentData,
+        visible: credentials[contentData.credential_group_name]?.hasCredential ?? false,
+      }));
+    }
+  );

--- a/rp/frontend/src/lib/stores/credentials.store.ts
+++ b/rp/frontend/src/lib/stores/credentials.store.ts
@@ -1,0 +1,32 @@
+import { writable } from 'svelte/store';
+
+type Credential = {
+  groupName: string;
+  timestampMillis: number;
+  hasCredential: boolean;
+};
+type CredentialsStoreData = Record<string, Credential>;
+
+const initStore = () => {
+  const { update, subscribe, set } = writable<CredentialsStoreData>({});
+
+  return {
+    subscribe,
+    reset: () => {
+      set({});
+    },
+    setCredential: ({ groupName, hasCredential }: { groupName: string; hasCredential: boolean }) =>
+      update((storeData) => {
+        return {
+          ...storeData,
+          [groupName]: {
+            groupName,
+            timestampMillis: Date.now(),
+            hasCredential,
+          },
+        };
+      }),
+  };
+};
+
+export const credentialsStore = initStore();

--- a/rp/frontend/src/routes/+page.svelte
+++ b/rp/frontend/src/routes/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import ImagesGrid from '$lib/components/ImagesGrid.svelte';
   import type { Readable } from 'svelte/store';
-  import type { ContentData } from '../declarations/rp/rp.did';
-  import { getExclusiveContentDataSortedByCreatedTimestamp } from '$lib/stores/content-data.store';
   import { authStore } from '$lib/stores/auth.store';
+  import {
+    getVisibleContentData,
+    type VisibleContentData,
+  } from '$lib/stores/content-data-visible.store';
 
-  let contentDataStore: Readable<ContentData[]>;
-  $: contentDataStore = getExclusiveContentDataSortedByCreatedTimestamp($authStore.identity);
+  let contentDataStore: Readable<VisibleContentData[]>;
+  $: contentDataStore = getVisibleContentData($authStore.identity);
 </script>
 
 <h1 class="h1 text-center">View and Share Content</h1>


### PR DESCRIPTION
Main motivation is to render the images for which the user has the credentials.

In this PR:
* New store credentialsStore.
* New derived store contentDataVisibleStore from credentialsStore and contentDataStore.
* Rename getCredential service to loadCredential.
* Store credential data in credentialsStore in loadCredential service.
* New type `VisibleContentData` that extends `ContentData` to add whether image should be shown or not.
* Show image in ImagesGrid when user has the credential.
* Style the Modal and ViewExclusiveContentModal to make it nicer to the eye.
* Use the credentialsStore in ViewExclusiveContentModal to render image after credential.
* Reset credentialsStore on logout.