### PR TITLE
Use roles not tabs

### DIFF
--- a/issuer/frontend/src/lib/components/SettingsDropdown.svelte
+++ b/issuer/frontend/src/lib/components/SettingsDropdown.svelte
@@ -4,15 +4,31 @@
   import IconCopy from './IconCopy.svelte';
   import PopoverDropdown from '$lib/ui-components/elements/PopoverDropdown.svelte';
   import NavBarItem from '$lib/ui-components/elements/NavBarItem.svelte';
+  import { goto } from '$app/navigation';
+
+  export let currentRole: 'User' | 'Issuer';
 
   let principal: string;
   $: principal = $authStore.identity?.getPrincipal().toText() ?? '';
 
   const copyToClipboard = async () => await navigator.clipboard.writeText(principal);
+
+  const switchRole = () => {
+    if (currentRole === 'User') {
+      goto('/issuer-center');
+    } else {
+      goto('/credentials');
+    }
+  };
 </script>
 
 <PopoverDropdown>
   <ul>
+    <li>
+      <NavBarItem on:click={switchRole}
+        >{`Switch to ${currentRole === 'Issuer' ? 'User' : 'Issuer'}`}</NavBarItem
+      >
+    </li>
     <li>
       <NavBarItem on:click={copyToClipboard}>
         <span><IconCopy /></span>

--- a/issuer/frontend/src/lib/services/set-theme.ts
+++ b/issuer/frontend/src/lib/services/set-theme.ts
@@ -1,11 +1,11 @@
 import { browser } from '$app/environment';
 
-const CREDENTIALS_THEME = 'modern';
+const USER_THEME = 'modern';
 const ISSUER_THEME = 'wintry';
-type Role = 'issuer' | 'credentials';
+type Role = 'issuer' | 'user';
 const themeMapper: Record<Role, string> = {
-  issuer: CREDENTIALS_THEME,
-  credentials: ISSUER_THEME,
+  issuer: ISSUER_THEME,
+  user: USER_THEME,
 };
 
 export const setTheme = (role: Role) => {

--- a/issuer/frontend/src/lib/ui-components/elements/Heading.svelte
+++ b/issuer/frontend/src/lib/ui-components/elements/Heading.svelte
@@ -1,9 +1,22 @@
 <script lang="ts">
   export let level: '1' | '2' | '3' | '4' | '5' | '6';
+  export let align: 'left' | 'middle' = 'left';
 
   const component = `h${level}`;
+  let levelClasses = {
+    1: 'h1',
+    2: 'h2',
+    3: 'h3',
+    4: 'h4',
+    5: 'h5',
+    6: 'h6',
+  };
+  let alignClasses = {
+    left: 'text-left',
+    middle: 'text-center',
+  };
 </script>
 
-<svelte:element this={component} class={component}>
+<svelte:element this={component} class={`${levelClasses[level]} ${alignClasses[align]}`}>
   <slot />
 </svelte:element>

--- a/issuer/frontend/src/lib/ui-components/page-layouts/DefaultPage.svelte
+++ b/issuer/frontend/src/lib/ui-components/page-layouts/DefaultPage.svelte
@@ -3,8 +3,9 @@
 </script>
 
 <section class="flex flex-col gap-8">
+  <slot name="nav" />
   <slot name="callout" />
-  <Heading level="1">
+  <Heading align="middle" level="1">
     <slot name="title" />
   </Heading>
   <div class="flex flex-col gap-6">

--- a/issuer/frontend/src/routes/(app)/+layout.svelte
+++ b/issuer/frontend/src/routes/(app)/+layout.svelte
@@ -8,6 +8,7 @@
   import SettingsDropdown from '$lib/components/SettingsDropdown.svelte';
   import { computePosition, autoUpdate, offset, shift, flip, arrow } from '@floating-ui/dom';
   import { storePopup } from '@skeletonlabs/skeleton';
+  import { page } from '$app/stores';
 
   storePopup.set({ computePosition, autoUpdate, offset, shift, flip, arrow });
 
@@ -16,6 +17,9 @@
   onMount(() => {
     syncAuth();
   });
+
+  let currentRole: 'User' | 'Issuer';
+  $: currentRole = $page.route.id === '/(app)/credentials' ? 'User' : 'Issuer';
 </script>
 
 <Modal />
@@ -26,10 +30,11 @@
   <svelte:fragment slot="header">
     <!-- App Bar -->
     <AppBar>
-      <a href="/home" class="text-xl uppercase font-bold" aria-label="Go to Home" slot="lead"
-        >VC Playground
-      </a>
-      <SettingsDropdown slot="trail" />
+      <span slot="lead" class="flex gap-4 items-center">
+        <span class="text-xl uppercase text-surface-500">VC Playground</span>
+        <span class="text-xl font-heading-token font-bold">{currentRole}</span>
+      </span>
+      <SettingsDropdown slot="trail" {currentRole} />
     </AppBar>
   </svelte:fragment>
   <MainWrapper>

--- a/issuer/frontend/src/routes/(app)/credentials/+page.svelte
+++ b/issuer/frontend/src/routes/(app)/credentials/+page.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import IssuersList from '$lib/components/IssuersList.svelte';
+  import AuthGuard from '$lib/components/AuthGuard.svelte';
+  import { authStore } from '$lib/stores/auth.store';
+  import { getAllIssuersStore } from '$lib/stores/issuers.store';
+  import TestIdWrapper from '$lib/ui-components/elements/TestIdWrapper.svelte';
+  import MemberIssuerItem from '$lib/components/MemberIssuerItem.svelte';
+  import { setTheme } from '$lib/services/set-theme';
+  import DefaultPage from '$lib/ui-components/page-layouts/DefaultPage.svelte';
+  import HeadingSkeleton from '$lib/ui-components/elements/HeadingSkeleton.svelte';
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    setTheme('user');
+  });
+
+  let allIssuersStore;
+  $: allIssuersStore = getAllIssuersStore($authStore.identity);
+</script>
+
+<TestIdWrapper testId="home-route">
+  <AuthGuard>
+    <DefaultPage>
+      <svelte:fragment slot="title">Credentials</svelte:fragment>
+      <IssuersList issuers={$allIssuersStore}>
+        {#each $allIssuersStore ?? [] as issuer}
+          <MemberIssuerItem {issuer} />
+        {/each}
+      </IssuersList>
+    </DefaultPage>
+    <DefaultPage slot="skeleton">
+      <svelte:fragment slot="title"><HeadingSkeleton size="lg" /></svelte:fragment>
+      <IssuersList issuers={undefined} />
+    </DefaultPage>
+  </AuthGuard>
+</TestIdWrapper>

--- a/issuer/frontend/src/routes/(app)/issuers/+page.svelte
+++ b/issuer/frontend/src/routes/(app)/issuers/+page.svelte
@@ -22,6 +22,13 @@
   import type { Readable } from 'svelte/store';
   import type { MemberData } from '../../../declarations/meta_issuer.did';
   import { RP_ORIGIN } from '$lib/constants/env-vars';
+  import { onMount } from 'svelte';
+  import { setTheme } from '$lib/services/set-theme';
+  import NavBarItem from '$lib/ui-components/elements/NavBarItem.svelte';
+
+  onMount(() => {
+    setTheme('issuer');
+  });
 
   let issuerName: string | null;
   $: issuerName = browser ? $page.url.searchParams.get(ISSUER_PARAM) : null;
@@ -57,9 +64,11 @@
 
 <AuthGuard>
   <DefaultPage>
-    <Callout slot="callout">
-      <p>🎉 You are the issuer of this credential type.</p>
-    </Callout>
+    <ol class="breadcrumb" slot="nav">
+      <li class="crumb"><a class="anchor" href="/issuer-center">Issuer Control Center</a></li>
+      <li class="crumb-separator" aria-hidden>&rsaquo;</li>
+      <li>{$issuerStore?.group_name ?? ''}</li>
+    </ol>
     <svelte:fragment slot="title">{$issuerStore?.group_name}</svelte:fragment>
     <div>
       <Button variant="primary" href={RP_ORIGIN}>Test In relying party</Button>

--- a/issuer/frontend/src/routes/(landing-page)/+page.svelte
+++ b/issuer/frontend/src/routes/(landing-page)/+page.svelte
@@ -11,7 +11,7 @@
 
   const loginUser = async () => {
     await login();
-    goto('/home');
+    goto('/credentials');
   };
 
   onMount(() => {
@@ -20,7 +20,7 @@
 
   $: {
     if ($authStore.identity !== null && $authStore.identity !== undefined) {
-      goto('/home');
+      goto('/credentials');
     }
   }
 </script>

--- a/issuer/frontend/src/routes/+layout.svelte
+++ b/issuer/frontend/src/routes/+layout.svelte
@@ -1,8 +1,0 @@
-<script lang="ts">
-  import { LightSwitch } from '@skeletonlabs/skeleton';
-</script>
-
-<slot />
-<span class="fixed bottom-0 right-0 p-4">
-  <LightSwitch />
-</span>


### PR DESCRIPTION
Main motivation is to change how the user navigates the meta-issuer to switching roles instead of tabs.

Changes:
* Remove theme switcher. This way it's clear which color is each role. To be defined whether we force for all users the same dark or light theme.
* Add an item in the nav bar dropdown to switch roles.
* Add alignment to the center to the page title.
* Align naming of roles to Issuer and User.
* Add a breadcrumb to the issuer detail page to go back to the issuer center.
* Add the current role in the header.
* Split current home into two pages: issuer-center/+page.svelte and credentials/+page.svelte
* Set the theme of the role in each page.
* Landing page goes to `/credentials` for now.