### PR TITLE
Add user- and issuer-nicknames, remove notes

### DIFF
--- a/issuer/meta_issuer.did
+++ b/issuer/meta_issuer.did
@@ -111,9 +111,18 @@ type HttpResponse = record {
     body: blob;
 };
 
-/// Types for group and membership management.
+/// Types for user, group and group membership management.
 
 type TimestampNs = nat64;
+
+type UserData = record {
+    user_nickname : opt text;
+    issuer_nickname : opt text;
+};
+
+type SetUserRequest = record {
+    user_data : UserData
+};
 
 type ListGroupsRequest = record {
     group_name_substring : opt text;
@@ -129,7 +138,6 @@ type AddGroupRequest = record {
 
 type JoinGroupRequest = record {
     group_name : text;
-    note : text
 };
 
 type MembershipUpdate = record {
@@ -140,7 +148,6 @@ type MembershipUpdate = record {
 type UpdateMembershipRequest = record {
     group_name : text;
     updates : vec MembershipUpdate;
-
 };
 
 type GroupStats = record {
@@ -163,7 +170,7 @@ type PublicGroupData = record {
 
 type MemberData = record {
     member: principal;
-    note: text;
+    nickname: text;
     joined_timestamp_ns : TimestampNs;
     membership_status: MembershipStatus;
 };
@@ -180,6 +187,7 @@ type PublicGroupsData = record {
 
 type GroupsError = variant {
     NotAuthorized : text;
+    NotAuthenticated : text;
     AlreadyExists : text;
     NotFound: text;
     Internal : text;
@@ -195,7 +203,9 @@ service: (opt IssuerConfig) -> {
     /// Configure the issuer (e.g. set the root key), used for deployment/testing.
     configure: (IssuerConfig) -> ();
 
-    /// API for obtaining information about groups and group membership.
+    /// API for setting/getting information about users, groups and group membership.
+    set_user : (SetUserRequest) -> (variant { Ok ; Err : GroupsError;}); /// authenticated
+    get_user : () -> (variant { Ok : UserData ; Err : GroupsError;}) query; /// authenticated
     list_groups : (ListGroupsRequest) -> (variant { Ok : PublicGroupsData; Err : GroupsError;}) query;  /// public
     get_group : (GetGroupRequest) -> (variant { Ok : FullGroupData; Err : GroupsError;}) query;  /// authenticated, only for the owner
     add_group : (AddGroupRequest) -> (variant { Ok : FullGroupData; Err : GroupsError;});  /// authenticated

--- a/issuer/src/groups_api.rs
+++ b/issuer/src/groups_api.rs
@@ -1,6 +1,17 @@
 use candid::{CandidType, Deserialize, Principal};
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct UserData {
+    pub user_nickname: Option<String>,
+    pub issuer_nickname: Option<String>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct SetUserRequest {
+    pub user_data: UserData,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct ListGroupsRequest {
     pub group_name_substring: Option<String>,
 }
@@ -18,7 +29,6 @@ pub struct AddGroupRequest {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct JoinGroupRequest {
     pub group_name: String,
-    pub note: String,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -57,7 +67,7 @@ pub struct PublicGroupData {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct MemberData {
     pub member: Principal,
-    pub note: String,
+    pub nickname: String,
     pub joined_timestamp_ns: u64,
     pub membership_status: MembershipStatus,
 }
@@ -88,6 +98,7 @@ pub struct PublicGroupsData {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum GroupsError {
     NotAuthorized(String),
+    NotAuthenticated(String),
     AlreadyExists(String),
     NotFound(String),
     Internal(String),

--- a/issuer/tests/dapp_management.rs
+++ b/issuer/tests/dapp_management.rs
@@ -110,7 +110,6 @@ fn should_retain_groups_upgrade() -> Result<(), CallError> {
     add_group_with_member(
         group_name,
         authorized_principal,
-        "Alice",
         authorized_principal,
         &env,
         issuer_id,

--- a/issuer/tests/issue_credentials.rs
+++ b/issuer/tests/issue_credentials.rs
@@ -177,7 +177,6 @@ fn should_fail_get_credential_for_wrong_sender() {
     add_group_with_member(
         DUMMY_GROUP_NAME,
         authorized_principal,
-        "Alice",
         authorized_principal,
         &env,
         issuer_id,
@@ -285,7 +284,6 @@ fn should_prepare_early_adopter_credential_for_authorized_principal() {
     add_group_with_member(
         DUMMY_GROUP_NAME,
         authorized_principal,
-        "Alice",
         authorized_principal,
         &env,
         issuer_id,
@@ -361,7 +359,6 @@ fn should_issue_credential_e2e() -> Result<(), CallError> {
     add_group_with_member(
         DUMMY_GROUP_NAME,
         authorized_principal,
-        "Alice",
         authorized_principal,
         &env,
         issuer_id,


### PR DESCRIPTION
 - Add per-user nicknames for the roles of "user" and "issuers", with the corresponding APIs for setting/getting the nicknames.
 - Use "user"-nickname for group membership (instead of "note" field). 
 - Adjust the candid-API and tests.