### PR TITLE
Change group-key to (group_name, owner)-tuple

### DIFF
--- a/issuer/meta_issuer.did
+++ b/issuer/meta_issuer.did
@@ -138,6 +138,7 @@ type AddGroupRequest = record {
 
 type JoinGroupRequest = record {
     group_name : text;
+    owner : principal;
 };
 
 type MembershipUpdate = record {
@@ -163,8 +164,9 @@ type MembershipStatus = variant {
 
 type PublicGroupData = record {
    group_name : text;
+   owner : principal;
+   issuer_nickname : text;
    stats : GroupStats;
-   is_owner : opt bool;  // set only for authenticated calls
    membership_status: opt MembershipStatus;  // set only for authenticated calls
 };
 
@@ -177,6 +179,8 @@ type MemberData = record {
 
 type FullGroupData = record {
     group_name : text;
+    owner : principal;
+    issuer_nickname : text;
     stats : GroupStats;
     members : vec MemberData;
 };

--- a/issuer/src/groups_api.rs
+++ b/issuer/src/groups_api.rs
@@ -29,6 +29,7 @@ pub struct AddGroupRequest {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct JoinGroupRequest {
     pub group_name: String,
+    pub owner: Principal,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -59,8 +60,9 @@ pub enum MembershipStatus {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PublicGroupData {
     pub group_name: String,
+    pub owner: Principal,
+    pub issuer_nickname: String,
     pub stats: GroupStats,
-    pub is_owner: Option<bool>,
     pub membership_status: Option<MembershipStatus>,
 }
 
@@ -75,6 +77,8 @@ pub struct MemberData {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct FullGroupData {
     pub group_name: String,
+    pub owner: Principal,
+    pub issuer_nickname: String,
     pub stats: GroupStats,
     pub members: Vec<MemberData>,
 }
@@ -83,8 +87,9 @@ impl From<FullGroupData> for PublicGroupData {
     fn from(full_data: FullGroupData) -> Self {
         PublicGroupData {
             group_name: full_data.group_name,
+            owner: full_data.owner,
+            issuer_nickname: full_data.issuer_nickname,
             stats: full_data.stats,
-            is_owner: None,
             membership_status: None,
         }
     }

--- a/issuer/tests/util/mod.rs
+++ b/issuer/tests/util/mod.rs
@@ -127,7 +127,7 @@ pub fn add_group_with_member(
     canister_id: Principal,
 ) {
     do_add_group(group_name, owner, env, canister_id);
-    do_join_group(group_name, member, env, canister_id);
+    do_join_group(group_name, owner, member, env, canister_id);
     do_update_membership(
         group_name,
         vec![MembershipUpdate {
@@ -179,6 +179,7 @@ pub fn do_get_group(
 
 pub fn do_join_group(
     group_name: &str,
+    owner: Principal,
     caller: Principal,
     env: &StateMachine,
     canister_id: Principal,
@@ -189,6 +190,7 @@ pub fn do_join_group(
         caller,
         JoinGroupRequest {
             group_name: group_name.to_string(),
+            owner,
         },
     )
     .expect("API call failed")


### PR DESCRIPTION
Previously `group_name` was uniquely identifying any group.  As we want `group_name` to represent a "credential type", where different users should be able issue credentials of the same type (i.e. create groups with an identical name), this PR changes the unique identifier of a group to be a tuple (`group_name`, `owner`), where `owner` is the principal of the user that creates the group.  This implies that also credential spec is changing, as in order to join a group, one must now specify the tuple (`group_name`, `owner`) identifying the desired group. 