### PR TITLE
Adjust RP to the issuer's change to use (group_name, owner)-tuples as keys

### DIFF
--- a/rp/rp.did
+++ b/rp/rp.did
@@ -34,6 +34,7 @@ type ContentData = record {
     created_timestamp_ns: TimestampNs;
     url: text;
     credential_group_name: text;
+    credential_group_owner: principal;
 };
 
 type ExclusiveContentList = record {
@@ -45,6 +46,7 @@ type AddExclusiveContentRequest = record {
     content_name: text;
     url: text;
     credential_group_name: text;
+    credential_group_owner: principal;
 };
 
 /// Types related to HTTP handling

--- a/rp/src/main.rs
+++ b/rp/src/main.rs
@@ -39,6 +39,7 @@ struct ExclusiveContentRecord {
     created_timestamp_ns: u64,
     url: String,
     credential_group_name: String,
+    credential_group_owner: Principal,
 }
 
 impl Storable for ImageRecord {
@@ -183,6 +184,7 @@ fn list_exclusive_content(
                 url: record.url,
                 created_timestamp_ns: record.created_timestamp_ns,
                 credential_group_name: record.credential_group_name,
+                credential_group_owner: record.credential_group_owner,
             })
         }
         Ok(ExclusiveContentList {
@@ -201,6 +203,7 @@ fn add_exclusive_content(req: AddExclusiveContentRequest) -> Result<ContentData,
             url: req.url,
             created_timestamp_ns: time(),
             credential_group_name: req.credential_group_name,
+            credential_group_owner: req.credential_group_owner,
         };
 
         content.insert(
@@ -210,6 +213,7 @@ fn add_exclusive_content(req: AddExclusiveContentRequest) -> Result<ContentData,
                 created_timestamp_ns: data.created_timestamp_ns,
                 url: data.url.clone(),
                 credential_group_name: data.credential_group_name.clone(),
+                credential_group_owner: data.credential_group_owner,
             },
         );
         Ok(data)

--- a/rp/src/rp_api.rs
+++ b/rp/src/rp_api.rs
@@ -31,6 +31,7 @@ pub struct ContentData {
     pub created_timestamp_ns: u64,
     pub url: String,
     pub credential_group_name: String,
+    pub credential_group_owner: Principal,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -43,6 +44,7 @@ pub struct AddExclusiveContentRequest {
     pub content_name: String,
     pub url: String,
     pub credential_group_name: String,
+    pub credential_group_owner: Principal,
 }
 
 // Types related to HTTP-endpoint.

--- a/rp/tests/dapp_management.rs
+++ b/rp/tests/dapp_management.rs
@@ -1,7 +1,7 @@
 //! Tests related to general dapp management.
 
 use canister_tests::api::http_request;
-use canister_tests::framework::{env, principal_1, time};
+use canister_tests::framework::{env, principal_1, principal_2, time};
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use ic_response_verification::types::VerificationInfo;
 use ic_response_verification::verify_request_response_pair;
@@ -129,18 +129,27 @@ fn should_retain_data_after_upgrade() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_rp(&env, None);
     let caller = principal_1();
+    let group_owner = principal_2();
 
     let content_name = "Some content name";
     let group_name = "Some group name";
     let url = "http://example.com";
-    let content_data =
-        do_add_exclusive_content(content_name, url, group_name, caller, &env, canister_id);
+    let content_data = do_add_exclusive_content(
+        content_name,
+        url,
+        group_name,
+        group_owner,
+        caller,
+        &env,
+        canister_id,
+    );
     let expected_content_data = ContentData {
         owner: caller,
         content_name: content_name.to_string(),
         created_timestamp_ns: content_data.created_timestamp_ns,
         url: url.to_string(),
         credential_group_name: group_name.to_string(),
+        credential_group_owner: group_owner,
     };
     let content_list = do_list_exclusive_content(&env, None, canister_id);
     assert_eq!(content_list.content_items.len(), 1);

--- a/rp/tests/manage_content.rs
+++ b/rp/tests/manage_content.rs
@@ -44,18 +44,27 @@ fn should_add_exclusive_content() {
     let env = env();
     let canister_id = install_rp(&env, None);
     let caller = principal_1();
+    let group_owner = principal_2();
 
     let content_name = "Some content name";
     let group_name = "Some group name";
     let url = "http://example.com";
-    let content_data =
-        do_add_exclusive_content(content_name, url, group_name, caller, &env, canister_id);
+    let content_data = do_add_exclusive_content(
+        content_name,
+        url,
+        group_name,
+        group_owner,
+        caller,
+        &env,
+        canister_id,
+    );
     let expected_content_data = ContentData {
         owner: caller,
         content_name: content_name.to_string(),
         created_timestamp_ns: content_data.created_timestamp_ns,
         url: url.to_string(),
         credential_group_name: group_name.to_string(),
+        credential_group_owner: group_owner,
     };
     assert_eq!(content_data, expected_content_data);
 }
@@ -65,12 +74,20 @@ fn should_list_exclusive_content() {
     let env = env();
     let canister_id = install_rp(&env, None);
     let caller = principal_1();
+    let group_owner = principal_2();
 
     let content_name = "Some content name";
     let group_name = "Some group name";
     let url = "http://example.com";
-    let content_data =
-        do_add_exclusive_content(content_name, url, group_name, caller, &env, canister_id);
+    let content_data = do_add_exclusive_content(
+        content_name,
+        url,
+        group_name,
+        group_owner,
+        caller,
+        &env,
+        canister_id,
+    );
     let content_list = do_list_exclusive_content(&env, None, canister_id);
     let expected_content_data = ContentData {
         owner: caller,
@@ -78,6 +95,7 @@ fn should_list_exclusive_content() {
         created_timestamp_ns: content_data.created_timestamp_ns,
         url: url.to_string(),
         credential_group_name: group_name.to_string(),
+        credential_group_owner: group_owner,
     };
     assert_eq!(content_list.content_items.len(), 1);
     assert_eq!(content_list.content_items[0], expected_content_data);
@@ -88,6 +106,7 @@ fn should_list_exclusive_content_multiple_items() {
     let env = env();
     let canister_id = install_rp(&env, None);
     let caller = [principal_1(), principal_2(), test_principal(42)];
+    let group_owner = principal_2();
 
     let content_name = [
         "Some content name 1",
@@ -102,6 +121,7 @@ fn should_list_exclusive_content_multiple_items() {
             content_name[i],
             url[i],
             group_name[i],
+            group_owner,
             caller[i],
             &env,
             canister_id,
@@ -112,6 +132,7 @@ fn should_list_exclusive_content_multiple_items() {
             created_timestamp_ns: content_data.created_timestamp_ns,
             url: url[i].to_string(),
             credential_group_name: group_name[i].to_string(),
+            credential_group_owner: group_owner,
         };
         expected_list.insert(content_name[i].to_string(), expected_content_data);
     }

--- a/rp/tests/util/mod.rs
+++ b/rp/tests/util/mod.rs
@@ -54,6 +54,7 @@ pub fn do_add_exclusive_content(
     content_name: &str,
     url: &str,
     credential_group_name: &str,
+    credential_group_owner: Principal,
     caller: Principal,
     env: &StateMachine,
     canister_id: Principal,
@@ -66,6 +67,7 @@ pub fn do_add_exclusive_content(
             content_name: content_name.to_string(),
             url: url.to_string(),
             credential_group_name: credential_group_name.to_string(),
+            credential_group_owner,
         },
     )
     .expect("API call failed")


### PR DESCRIPTION
In #78 issuer was changed to use (`group_name`, `owner`)-tuple to identify groups.  This PR propagates the changes to RP.