### PR TITLE
Add ic-domains-files to the canisters

### DIFF
--- a/issuer/frontend/static/.well-known/ic-domains
+++ b/issuer/frontend/static/.well-known/ic-domains
@@ -1,0 +1,1 @@
+metaissuer.vc

--- a/issuer/tests/dapp_management.rs
+++ b/issuer/tests/dapp_management.rs
@@ -62,24 +62,29 @@ fn issuer_canister_serves_http_assets() -> Result<(), CallError> {
     // for each asset and certification version, fetch the asset, check the HTTP status code, headers and certificate.
 
     for certification_version in 1..=2 {
-        let request = HttpRequest {
-            method: "GET".to_string(),
-            url: "/".to_string(),
-            headers: vec![],
-            body: ByteBuf::new(),
-            certificate_version: Some(certification_version),
-        };
-        let http_response = http_request(&env, canister_id, &request)?;
-        assert_eq!(http_response.status_code, 200);
-
-        let result = verify_response_certification(
-            &env,
-            canister_id,
-            request,
-            http_response,
-            certification_version,
-        );
-        assert_eq!(result.verification_version, certification_version);
+        for asset_name in ["/", "/.well-known/ic-domains"] {
+            let request = HttpRequest {
+                method: "GET".to_string(),
+                url: asset_name.to_string(),
+                headers: vec![],
+                body: ByteBuf::new(),
+                certificate_version: Some(certification_version),
+            };
+            let http_response = http_request(&env, canister_id, &request)?;
+            assert_eq!(
+                http_response.status_code, 200,
+                "failed for asset: {}",
+                asset_name
+            );
+            let result = verify_response_certification(
+                &env,
+                canister_id,
+                request,
+                http_response,
+                certification_version,
+            );
+            assert_eq!(result.verification_version, certification_version);
+        }
     }
 
     Ok(())

--- a/rp/frontend/static/.well-known/ic-domains
+++ b/rp/frontend/static/.well-known/ic-domains
@@ -1,0 +1,1 @@
+relyingparty.vc

--- a/rp/tests/dapp_management.rs
+++ b/rp/tests/dapp_management.rs
@@ -55,28 +55,33 @@ fn issuer_canister_serves_http_assets() -> Result<(), CallError> {
 
     // for each asset and certification version, fetch the asset, check the HTTP status code, headers and certificate.
     for certification_version in 1..=2 {
-        for image_name in [
-            "consensus.png",
-            "faultTolerance.png",
-            "infiniteScalability.png",
-            "internetIdentity.png",
-            "messageRouting.png",
-            "motoko.png",
-            "networkNervousSystem.png",
-            "peerToPeer.png",
-            "protocolUpgrade.png",
-            "sdk.png",
-            "serviceNervousSystem.png",
+        for asset_name in [
+            "/images/consensus.png",
+            "/images/faultTolerance.png",
+            "/images/infiniteScalability.png",
+            "/images/internetIdentity.png",
+            "/images/messageRouting.png",
+            "/images/motoko.png",
+            "/images/networkNervousSystem.png",
+            "/images/peerToPeer.png",
+            "/images/protocolUpgrade.png",
+            "/images/sdk.png",
+            "/images/serviceNervousSystem.png",
+            "/.well-known/ic-domains",
         ] {
             let request = HttpRequest {
                 method: "GET".to_string(),
-                url: format!("/images/{}", image_name),
+                url: asset_name.to_string(),
                 headers: vec![],
                 body: ByteBuf::new(),
                 certificate_version: Some(certification_version),
             };
             let http_response = http_request(&env, canister_id, &request)?;
-            assert_eq!(http_response.status_code, 200);
+            assert_eq!(
+                http_response.status_code, 200,
+                "failed for asset: {}",
+                asset_name
+            );
 
             let result = verify_response_certification(
                 &env,


### PR DESCRIPTION
Add `ic-domains` files to the canister, to enable custom domains (cf. [instructions](https://internetcomputer.org/docs/current/developer-docs/web-apps/custom-domains/using-custom-domains#step-2-create-a-file-named-ic-domains-in-your-canister-under-well-known-containing-the-custom-domain))