### PR TITLE
Simplify consent message

### DIFF
--- a/issuer/src/main.rs
+++ b/issuer/src/main.rs
@@ -666,10 +666,6 @@ fn get_derivation_origin(_hostname: &str) -> Result<DerivationOriginData, Deriva
     })
 }
 
-const VERIFIED_MEMBER_VC_CONSENT_EN: &str = r###"# Verified Member
-
-Credential stating that you are a member of group "###;
-
 pub fn get_vc_consent_message_en(
     credential_spec: &CredentialSpec,
 ) -> Result<Icrc21ConsentInfo, Icrc21Error> {
@@ -678,7 +674,7 @@ pub fn get_vc_consent_message_en(
             description: err,
         })),
         Ok((group_name, _owner)) => Ok(Icrc21ConsentInfo {
-            consent_message: format!("{} '{}'.", VERIFIED_MEMBER_VC_CONSENT_EN, group_name),
+            consent_message: format!("#\"{}\"", group_name),
             language: "en".to_string(),
         }),
     }

--- a/issuer/tests/issue_credentials.rs
+++ b/issuer/tests/issue_credentials.rs
@@ -49,7 +49,7 @@ fn should_get_vc_consent_message() {
         api::vc_consent_message(&env, canister_id, principal_1(), &consent_message_request)
             .expect("API call failed")
             .expect("Failed to obtain consent info");
-    assert!(consent_info.consent_message.contains("Verified Member"));
+    assert!(consent_info.consent_message.contains(DUMMY_GROUP_NAME));
 }
 
 #[test]


### PR DESCRIPTION
Reduce the consent message to contain just the group name.