### PR TITLE
Request credentials without AuthClient

### DIFF
--- a/rp/frontend/src/lib/services/auth-client.services.ts
+++ b/rp/frontend/src/lib/services/auth-client.services.ts
@@ -24,15 +24,10 @@ type IssuerData = {
   canisterId?: Principal;
 };
 
-/**
- * PROPOSAL OF HOW TO ADD VC FUNCTIONALITY TO THE AUTH CLIENT
- */
 export class AuthClientNew {
   private client: AuthClient;
   private derivationOrigin: string;
   private identityProvider: string;
-  private iiWindow: Window | null = null;
-  private nextFlowId = 0;
   /**
    * New parameters to add when creating the client
    */
@@ -86,78 +81,84 @@ export class AuthClientNew {
   logout() {
     return this.client.logout();
   }
-
-  /**
-   * New Functionality
-   */
-  requestCredential({
-    onSuccess,
-    onError,
-    credentialSpec,
-    credentialSubject,
-    issuerData,
-    windowOpenerFeatures,
-  }: {
-    onSuccess: (verifiablePresentation: string) => void | Promise<void>;
-    onError: (err?: string) => void | Promise<void>;
-    credentialSpec: CredentialSpec;
-    credentialSubject: Principal;
-    issuerData: IssuerData;
-    windowOpenerFeatures: string | undefined;
-  }) {
-    this.nextFlowId += 1;
-    const startFlow = (evnt: MessageEvent) => {
-      const req = {
-        id: String(this.nextFlowId),
-        jsonrpc: '2.0',
-        method: 'request_credential',
-        params: {
-          issuer: issuerData,
-          credentialSpec,
-          credentialSubject: credentialSubject.toText(),
-          derivationOrigin: this.derivationOrigin,
-        },
-      };
-      window.addEventListener('message', handleFlowFinished);
-      window.removeEventListener('message', handleFlowReady);
-      evnt.source?.postMessage(req, { targetOrigin: evnt.origin });
-    };
-    const finishFlow = async (evnt: MessageEvent) => {
-      try {
-        if (nonNullish(evnt.data?.error)) {
-          throw new Error(evnt.data.error);
-        }
-        // Make the presentation presentable
-        const verifiablePresentation = evnt.data?.result?.verifiablePresentation;
-        if (verifiablePresentation === undefined) {
-          // This should never happen
-          onError("Couldn't get the verifiable credential");
-        } else {
-          onSuccess(verifiablePresentation);
-        }
-      } catch (err) {
-        onError(`Error getting the verifiable credential: ${err}`);
-      } finally {
-        this.iiWindow?.close();
-        window.removeEventListener('message', handleFlowFinished);
-      }
-    };
-    const handleFlowFinished = (evnt: MessageEvent) => {
-      if (evnt.data?.method === 'vc-flow-ready') {
-        startFlow(evnt);
-      } else if (evnt.data?.id === String(this.nextFlowId)) {
-        finishFlow(evnt);
-      }
-    };
-    const handleFlowReady = (evnt: MessageEvent) => {
-      if (evnt.data?.method !== 'vc-flow-ready') {
-        return;
-      }
-      startFlow(evnt);
-    };
-    window.addEventListener('message', handleFlowReady);
-    const url = new URL(this.identityProvider);
-    url.pathname = 'vc-flow/';
-    this.iiWindow = window.open(url, '_blank', windowOpenerFeatures);
-  }
 }
+
+let iiWindow: Window | null = null;
+let nextFlowId = 0;
+/**
+ * PROPOSAL OF HOW TO ADD VC FUNCTIONALITY v2
+ */
+export const requestCredential = ({
+  onSuccess,
+  onError,
+  credentialSpec,
+  credentialSubject,
+  issuerData,
+  windowOpenerFeatures,
+  derivationOrigin,
+  identityProvider,
+}: {
+  onSuccess: (verifiablePresentation: string) => void | Promise<void>;
+  onError: (err?: string) => void | Promise<void>;
+  credentialSpec: CredentialSpec;
+  credentialSubject: Principal;
+  issuerData: IssuerData;
+  windowOpenerFeatures: string | undefined;
+  derivationOrigin: string | undefined;
+  identityProvider: string;
+}) => {
+  nextFlowId += 1;
+  const startFlow = (evnt: MessageEvent) => {
+    const req = {
+      id: String(nextFlowId),
+      jsonrpc: '2.0',
+      method: 'request_credential',
+      params: {
+        issuer: issuerData,
+        credentialSpec,
+        credentialSubject: credentialSubject.toText(),
+        derivationOrigin: derivationOrigin,
+      },
+    };
+    window.addEventListener('message', handleFlowFinished);
+    window.removeEventListener('message', handleFlowReady);
+    evnt.source?.postMessage(req, { targetOrigin: evnt.origin });
+  };
+  const finishFlow = async (evnt: MessageEvent) => {
+    try {
+      if (nonNullish(evnt.data?.error)) {
+        throw new Error(evnt.data.error);
+      }
+      // Make the presentation presentable
+      const verifiablePresentation = evnt.data?.result?.verifiablePresentation;
+      if (verifiablePresentation === undefined) {
+        // This should never happen
+        onError("Couldn't get the verifiable credential");
+      } else {
+        onSuccess(verifiablePresentation);
+      }
+    } catch (err) {
+      onError(`Error getting the verifiable credential: ${err}`);
+    } finally {
+      iiWindow?.close();
+      window.removeEventListener('message', handleFlowFinished);
+    }
+  };
+  const handleFlowFinished = (evnt: MessageEvent) => {
+    if (evnt.data?.method === 'vc-flow-ready') {
+      startFlow(evnt);
+    } else if (evnt.data?.id === String(nextFlowId)) {
+      finishFlow(evnt);
+    }
+  };
+  const handleFlowReady = (evnt: MessageEvent) => {
+    if (evnt.data?.method !== 'vc-flow-ready') {
+      return;
+    }
+    startFlow(evnt);
+  };
+  window.addEventListener('message', handleFlowReady);
+  const url = new URL(identityProvider);
+  url.pathname = 'vc-flow/';
+  iiWindow = window.open(url, '_blank', windowOpenerFeatures);
+};

--- a/rp/frontend/src/lib/services/load-credential.services.ts
+++ b/rp/frontend/src/lib/services/load-credential.services.ts
@@ -2,38 +2,28 @@ import { validateCredentials } from '$lib/api/validateCredentials.api';
 import { credentialsStore } from '$lib/stores/credentials.store';
 import { isNullish } from '$lib/utils/is-nullish.utils';
 import { popupCenter } from '$lib/utils/login-popup.utils';
-import { nonNullish } from '$lib/utils/non-nullish';
 import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
-import type { ToastStore } from '@skeletonlabs/skeleton';
-import { getAuthClient } from './auth-client.services';
+import { requestCredential } from './auth-client.services';
 
-const II_URL = import.meta.env.VITE_INTERNET_IDENTITY_URL;
 const ISSUER_ORIGIN = import.meta.env.VITE_ISSUER_ORIGIN;
 const ISSUER_CANISTER_ID = import.meta.env.VITE_ISSUER_CANISTER_ID;
-
-let iiWindow: Window | null = null;
-let nextFlowId = 0;
 
 export const loadCredential = async ({
   groupName,
   owner,
   identity,
-  toastStore,
 }: {
   groupName: string;
   owner: Principal;
   identity: Identity | undefined | null;
-  toastStore: ToastStore;
 }): Promise<null> => {
-  nextFlowId += 1;
   if (isNullish(identity)) {
     return null;
   }
   console.info('Loading credential for', groupName, owner.toText());
-  const authClient = await getAuthClient();
   return new Promise<null>((resolve) => {
-    authClient.requestCredential({
+    requestCredential({
       onSuccess: async (verifiablePresentation: string) => {
         const isValidCredential = await validateCredentials({
           identity,
@@ -82,6 +72,8 @@ export const loadCredential = async ({
       },
       credentialSubject: identity.getPrincipal(),
       windowOpenerFeatures: popupCenter(),
+      identityProvider: import.meta.env.VITE_INTERNET_IDENTITY_URL,
+      derivationOrigin: import.meta.env.VITE_RP_DERIVATION_ORIGIN,
     });
   });
 };


### PR DESCRIPTION
Main motivation is to provide a second draft of how to write the JS client to request credentials.

In this PR, `requestCredentials` is just a function instead of a method of AuthClient.

The main difference is that the function needs two parameters more: `derivationOrigin` and `identityProvider` which were passed when the "new" `AuthClient` was created before to be reused on login and requesting credentials.

To be honest, I'm not sure about the best approach. On one hand, we don't need to store any state for the verifiable credentials flow, that's why it makes me wonder whether just a function is simpler. On the other hand, there is a coupling with the login with `derivationOrigin` and `identityProvider`.

`derivationOrigin` and `identityProvider` need to be the same when logging in and when verifying the credential. The `identityProvider` is obvious, but remembering the `derivationOrigin` which is optional is more dangerous. Maybe we should set `derivationOrigin` as mandatory parameter but that can be set to `null`.

I'd appreciate feedback on the abstraction rather than the implementation (but it's also welcome):

* Do we want one function or a method on AuthClient?
* Do we prefer callbacks like `AuthClient.login`: `onSuccess` and `onError` or should it be an `async` function.