### PR TITLE
Extend groups-API to allow various VC types with arguments

### DIFF
--- a/issuer/meta_issuer.did
+++ b/issuer/meta_issuer.did
@@ -180,6 +180,7 @@ type AddGroupRequest = record {
 type JoinGroupRequest = record {
     group_name : text;
     owner : principal;
+    vc_arguments: opt VcArguments;
 };
 
 type MembershipUpdate = record {
@@ -203,12 +204,24 @@ type MembershipStatus = variant {
     Rejected;
 };
 
+type VcArguments = vec record { text; ArgumentValue };
+
+type GroupType = record {
+    group_name: text;
+    credential_spec: CredentialSpec;
+};
+
+type GroupTypes = record {
+    types: vec GroupType;
+};
+
 type PublicGroupData = record {
    group_name : text;
    owner : principal;
    issuer_nickname : text;
    stats : GroupStats;
    membership_status: opt MembershipStatus;  // set only for authenticated calls
+   vc_arguments: opt VcArguments ;  // set only for authenticated calls
 };
 
 type MemberData = record {
@@ -216,6 +229,7 @@ type MemberData = record {
     nickname: text;
     joined_timestamp_ns : TimestampNs;
     membership_status: MembershipStatus;
+    vc_arguments: opt VcArguments;
 };
 
 type FullGroupData = record {
@@ -251,6 +265,7 @@ service: (opt IssuerInit) -> {
     /// API for setting/getting information about users, groups and group membership.
     set_user : (SetUserRequest) -> (variant { Ok ; Err : GroupsError;}); /// authenticated
     get_user : () -> (variant { Ok : UserData ; Err : GroupsError;}) query; /// authenticated
+    group_types : () -> (variant { Ok : GroupTypes; Err : GroupsError;}) query; /// public
     list_groups : (ListGroupsRequest) -> (variant { Ok : PublicGroupsData; Err : GroupsError;}) query;  /// public
     get_group : (GetGroupRequest) -> (variant { Ok : FullGroupData; Err : GroupsError;}) query;  /// authenticated, only for the owner
     add_group : (AddGroupRequest) -> (variant { Ok : FullGroupData; Err : GroupsError;});  /// authenticated

--- a/issuer/src/groups_api.rs
+++ b/issuer/src/groups_api.rs
@@ -1,4 +1,25 @@
 use candid::{CandidType, Deserialize, Principal};
+use std::collections::BTreeMap;
+
+#[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize, Ord, PartialOrd)]
+pub enum ArgumentValue {
+    String(String),
+    Int(i32),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct CredentialSpec {
+    pub credential_type: String,
+    pub arguments: Option<VcArguments>,
+}
+
+pub type VcArguments = BTreeMap<String, ArgumentValue>;
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct GroupType {
+    pub group_name: String,
+    pub credential_spec: CredentialSpec,
+}
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct UserData {
@@ -30,6 +51,7 @@ pub struct AddGroupRequest {
 pub struct JoinGroupRequest {
     pub group_name: String,
     pub owner: Principal,
+    pub vc_arguments: Option<VcArguments>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -58,12 +80,18 @@ pub enum MembershipStatus {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct GroupTypes {
+    pub types: Vec<GroupType>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PublicGroupData {
     pub group_name: String,
     pub owner: Principal,
     pub issuer_nickname: String,
     pub stats: GroupStats,
     pub membership_status: Option<MembershipStatus>,
+    pub vc_arguments: Option<VcArguments>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -72,6 +100,7 @@ pub struct MemberData {
     pub nickname: String,
     pub joined_timestamp_ns: u64,
     pub membership_status: MembershipStatus,
+    pub vc_arguments: Option<VcArguments>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -91,6 +120,7 @@ impl From<FullGroupData> for PublicGroupData {
             issuer_nickname: full_data.issuer_nickname,
             stats: full_data.stats,
             membership_status: None,
+            vc_arguments: None,
         }
     }
 }

--- a/issuer/src/main.rs
+++ b/issuer/src/main.rs
@@ -318,7 +318,6 @@ fn set_user(req: SetUserRequest) -> Result<(), GroupsError> {
 }
 
 /// API for obtaining information about groups and group membership.
-/// API for setting/getting user data.
 
 #[query]
 #[candid_method(query)]

--- a/issuer/tests/manage_groups.rs
+++ b/issuer/tests/manage_groups.rs
@@ -12,9 +12,39 @@ use std::time::Duration;
 #[allow(dead_code)]
 mod util;
 use crate::util::{
-    api, do_add_group, do_get_group, do_get_user, do_join_group, do_set_user, do_update_membership,
-    install_issuer,
+    api, do_add_group, do_get_group, do_get_user, do_group_types, do_join_group, do_set_user,
+    do_update_membership, install_issuer,
 };
+
+#[test]
+fn should_return_group_types() {
+    let env = env();
+    let canister_id = install_issuer(&env, None);
+    let caller = principal_1();
+
+    let group_types = do_group_types(caller, &env, canister_id);
+    assert_eq!(group_types.types.len(), 4);
+    assert_eq!(group_types.types[0].group_name, "Verified Residence");
+    assert_eq!(
+        group_types.types[0].credential_spec.credential_type,
+        "VerifiedResidence"
+    );
+    assert_eq!(group_types.types[1].group_name, "Verified Age");
+    assert_eq!(
+        group_types.types[1].credential_spec.credential_type,
+        "VerifiedAge"
+    );
+    assert_eq!(group_types.types[2].group_name, "Verified Employment");
+    assert_eq!(
+        group_types.types[2].credential_spec.credential_type,
+        "VerifiedEmployment"
+    );
+    assert_eq!(group_types.types[3].group_name, "Verified Humanity");
+    assert_eq!(
+        group_types.types[3].credential_spec.credential_type,
+        "VerifiedHumanity"
+    );
+}
 
 #[test]
 fn should_set_user() {

--- a/issuer/tests/util/mod.rs
+++ b/issuer/tests/util/mod.rs
@@ -6,7 +6,7 @@ use ic_test_state_machine_client::{
 };
 use lazy_static::lazy_static;
 use meta_issuer::groups_api::{
-    AddGroupRequest, FullGroupData, GetGroupRequest, GroupsError, JoinGroupRequest,
+    AddGroupRequest, FullGroupData, GetGroupRequest, GroupTypes, GroupsError, JoinGroupRequest,
     ListGroupsRequest, MembershipStatus, MembershipUpdate, PublicGroupsData, SetUserRequest,
     UpdateMembershipRequest, UserData,
 };
@@ -132,6 +132,12 @@ pub fn do_get_user(caller: Principal, env: &StateMachine, canister_id: Principal
         .expect("Failed get_user")
 }
 
+pub fn do_group_types(caller: Principal, env: &StateMachine, canister_id: Principal) -> GroupTypes {
+    api::group_types(env, canister_id, caller)
+        .expect("API call failed")
+        .expect("Failed group_types")
+}
+
 pub fn add_group_with_member(
     group_name: &str,
     owner: Principal,
@@ -204,6 +210,7 @@ pub fn do_join_group(
         JoinGroupRequest {
             group_name: group_name.to_string(),
             owner,
+            vc_arguments: None,
         },
     )
     .expect("API call failed")
@@ -233,7 +240,7 @@ pub fn do_update_membership(
 /// Issuer API.
 pub mod api {
     use super::*;
-    use meta_issuer::groups_api::{SetUserRequest, UserData};
+    use meta_issuer::groups_api::{GroupTypes, SetUserRequest, UserData};
 
     pub fn configure(
         env: &StateMachine,
@@ -289,6 +296,14 @@ pub mod api {
             (get_credential_request,),
         )
         .map(|(x,)| x)
+    }
+
+    pub fn group_types(
+        env: &StateMachine,
+        canister_id: CanisterId,
+        sender: Principal,
+    ) -> Result<Result<GroupTypes, GroupsError>, CallError> {
+        query_candid_as(env, canister_id, sender, "group_types", ()).map(|(x,)| x)
     }
 
     pub fn get_user(


### PR DESCRIPTION
Extend issuer's group-API: 
- add `group-types`-endpoint that returns VC types supported by the issuer
- add optional VC arguments to the group membership records

The arguments passed are stored and returned upon retrieval, but there are no checks yet whether the arguments match the VC spec of a group.  The issuer still returns `VerifiedMember`-VCs for all groups, and the switch to VCs matching the group's spec will be added in a follow-up PR.  Also, the corresponding changes to RP-API will be in a separate PR.

