### PR TITLE
Change meta-issuer to issue various types of credentials, depending on the spec from request

### DIFF
--- a/issuer/src/main.rs
+++ b/issuer/src/main.rs
@@ -151,6 +151,73 @@ lazy_static! {
     // Seed and public key used for signing the credentials.
     static ref CANISTER_SIG_SEED: Vec<u8> = hash_bytes("MetaIssuer").to_vec();
     static ref CANISTER_SIG_PK: CanisterSigPublicKey = CanisterSigPublicKey::new(ic_cdk::id(), CANISTER_SIG_SEED.clone());
+
+    // Supported group types/credential types.
+    static ref GROUP_TYPES: Vec<GroupType> = vec![
+            GroupType {
+                group_name: "Verified Residence".to_string(),
+                credential_spec: OrdCredentialSpec {
+                    credential_type: "VerifiedResidence".to_string(),
+                    arguments: Some(
+                        vec![(
+                            "countryName".to_string(),
+                            OrdArgumentValue::String("<country>".to_string()),
+                        )]
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                    ),
+                },
+            },
+            GroupType {
+                group_name: "Verified Age".to_string(),
+                credential_spec: OrdCredentialSpec {
+                    credential_type: "VerifiedAge".to_string(),
+                    arguments: Some(
+                        vec![("ageAtLeast".to_string(), OrdArgumentValue::Int(18))]
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect(),
+                    ),
+                },
+            },
+            GroupType {
+                group_name: "Verified Employment".to_string(),
+                credential_spec: OrdCredentialSpec {
+                    credential_type: "VerifiedEmployment".to_string(),
+                    arguments: Some(
+                        vec![(
+                            "employerName".to_string(),
+                            OrdArgumentValue::String("<employer>".to_string()),
+                        )]
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                    ),
+                },
+            },
+            GroupType {
+                group_name: "Verified Humanity".to_string(),
+                credential_spec: OrdCredentialSpec {
+                    credential_type: "VerifiedHumanity".to_string(),
+                    arguments: None,
+                },
+            },
+        ];
+    static ref GROUP_NAME_FOR_CREDENTIAL_TYPE: BTreeMap<String, String> = {
+        let mut map = BTreeMap::new();
+        for group_type in GROUP_TYPES.iter() {
+            map.insert(group_type.credential_spec.credential_type.clone(), group_type.group_name.clone());
+        }
+        map
+    };
+    static ref CREDENTIAL_TYPE_FOR_GROUP_NAME: BTreeMap<String, String> = {
+        let mut map = BTreeMap::new();
+        for group_type in GROUP_TYPES.iter() {
+            map.insert(group_type.group_name.clone(), group_type.credential_spec.credential_type.clone());
+        }
+        map
+    };
 }
 
 /// Reserve the first stable memory page for the configuration stable cell.
@@ -323,57 +390,7 @@ fn set_user(req: SetUserRequest) -> Result<(), GroupsError> {
 #[candid_method(query)]
 fn group_types() -> Result<GroupTypes, GroupsError> {
     Ok(GroupTypes {
-        types: vec![
-            GroupType {
-                group_name: "Verified Residence".to_string(),
-                credential_spec: OrdCredentialSpec {
-                    credential_type: "VerifiedResidence".to_string(),
-                    arguments: Some(
-                        vec![(
-                            "countryName".to_string(),
-                            OrdArgumentValue::String("<country>".to_string()),
-                        )]
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect(),
-                    ),
-                },
-            },
-            GroupType {
-                group_name: "Verified Age".to_string(),
-                credential_spec: OrdCredentialSpec {
-                    credential_type: "VerifiedAge".to_string(),
-                    arguments: Some(
-                        vec![("ageAtLeast".to_string(), OrdArgumentValue::Int(18))]
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect(),
-                    ),
-                },
-            },
-            GroupType {
-                group_name: "Verified Employment".to_string(),
-                credential_spec: OrdCredentialSpec {
-                    credential_type: "VerifiedEmployment".to_string(),
-                    arguments: Some(
-                        vec![(
-                            "employerName".to_string(),
-                            OrdArgumentValue::String("<employer>".to_string()),
-                        )]
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect(),
-                    ),
-                },
-            },
-            GroupType {
-                group_name: "Verified Humanity".to_string(),
-                credential_spec: OrdCredentialSpec {
-                    credential_type: "VerifiedHumanity".to_string(),
-                    arguments: None,
-                },
-            },
-        ],
+        types: GROUP_TYPES.clone(),
     })
 }
 
@@ -628,10 +645,6 @@ fn authorize_vc_request(
 async fn prepare_credential(
     req: PrepareCredentialRequest,
 ) -> Result<PreparedCredentialData, IssueCredentialError> {
-    println!(
-        "*** id_alias VC JWS: {}",
-        req.signed_id_alias.credential_jws
-    );
     let alias_tuple = match authorize_vc_request(&req.signed_id_alias, &caller(), time().into()) {
         Ok(alias_tuple) => alias_tuple,
         Err(err) => return Err(err),
@@ -745,6 +758,18 @@ fn get_derivation_origin(_hostname: &str) -> Result<DerivationOriginData, Deriva
     })
 }
 
+fn args_to_string(spec: &CredentialSpec) -> String {
+    let mut args = String::new();
+    let Some(arguments) = &spec.arguments else {
+        return args;
+    };
+    for (key, value) in arguments.into_iter() {
+        let arg = format!("{}: {}\n", key, value);
+        args.push_str(&arg);
+    }
+    args
+}
+
 pub fn get_vc_consent_message_en(
     credential_spec: &CredentialSpec,
 ) -> Result<Icrc21ConsentInfo, Icrc21Error> {
@@ -752,58 +777,114 @@ pub fn get_vc_consent_message_en(
         Err(err) => Err(Icrc21Error::ConsentMessageUnavailable(Icrc21ErrorInfo {
             description: err,
         })),
-        Ok((group_name, _owner)) => Ok(Icrc21ConsentInfo {
-            consent_message: format!("# \"{}\"", group_name),
+        Ok((plain_spec, _owner)) => Ok(Icrc21ConsentInfo {
+            consent_message: format!(
+                "# \"{}\"\n{}",
+                plain_spec.credential_type,
+                args_to_string(&plain_spec)
+            ),
             language: "en".to_string(),
         }),
     }
 }
 
-fn verify_spec_and_get_group_name(spec: &CredentialSpec) -> Result<(String, Principal), String> {
-    if spec.credential_type.as_str() == "VerifiedMember" {
-        let Some(arguments) = &spec.arguments else {
-            return Err("Credential spec has no arguments".to_string());
-        };
-        if arguments.len() != 2 {
-            return Err("Credential spec has unexpected arguments".to_string());
-        }
-        let group_name_arg = "groupName";
-        let Some(value) = arguments.get(group_name_arg) else {
-            return Err(format!(
-                "Credential spec has no {}-argument",
-                group_name_arg
-            ));
-        };
-        let ArgumentValue::String(group_name) = value else {
-            return Err(format!(
-                "Credential spec has an unexpected value for {}-argument",
-                group_name_arg
-            ));
-        };
-
-        let owner_arg = "owner";
-        let Some(value) = arguments.get(owner_arg) else {
-            return Err(format!("Credential spec has no {}-argument", owner_arg));
-        };
-        let ArgumentValue::String(owner_text) = value else {
-            return Err(format!(
-                "Credential spec has an unexpected value for {}-argument",
-                owner_arg
-            ));
-        };
-        let Ok(owner) = Principal::from_text(owner_text) else {
-            return Err(format!(
-                "Credential spec has an invalid value for {}-argument",
-                owner_arg
-            ));
-        };
-        Ok((group_name.to_string(), owner))
+fn get_int_arg_value(arg_name: &str, spec: &CredentialSpec) -> Result<i32, String> {
+    let Some(arguments) = &spec.arguments else {
+        return Err("Credential spec has no arguments".to_string());
+    };
+    let Some(arg_value) = arguments.get(arg_name) else {
+        return Err(format!("Credential spec has no {}-argument", arg_name));
+    };
+    if let ArgumentValue::Int(int_value) = arg_value {
+        Ok(*int_value)
     } else {
         Err(format!(
-            "Credential {} is not supported",
-            spec.credential_type.as_str()
+            "Credential spec has an unexpected value for {}-argument",
+            arg_name
         ))
     }
+}
+
+fn get_string_arg_value(arg_name: &str, spec: &CredentialSpec) -> Result<String, String> {
+    let Some(arguments) = &spec.arguments else {
+        return Err("Credential spec has no arguments".to_string());
+    };
+    let Some(arg_value) = arguments.get(arg_name) else {
+        return Err(format!("Credential spec has no {}-argument", arg_name));
+    };
+    if let ArgumentValue::String(str_value) = arg_value {
+        Ok(str_value.clone())
+    } else {
+        Err(format!(
+            "Credential spec has an unexpected value for {}-argument",
+            arg_name
+        ))
+    }
+}
+
+fn check_arg_number(expected_arg_number: usize, spec: &CredentialSpec) -> Result<(), String> {
+    let Some(arguments) = &spec.arguments else {
+        if expected_arg_number == 0 {
+            return Ok(());
+        } else {
+            return Err(format!(
+                "Credential spec has wrong number of arguments, expected {}, got none",
+                expected_arg_number
+            ));
+        }
+    };
+    if arguments.len() == expected_arg_number {
+        return Ok(());
+    } else {
+        return Err(format!(
+            "Credential spec has wrong number of arguments, expected {}, got {}",
+            expected_arg_number,
+            arguments.len()
+        ));
+    }
+}
+
+fn get_owner_from_spec(spec: &CredentialSpec) -> Result<(CredentialSpec, Principal), String> {
+    let owner = get_string_arg_value("owner", spec)?;
+    let mut plain_spec = spec.to_owned();
+    plain_spec
+        .arguments
+        .as_mut()
+        .unwrap()
+        .remove("owner")
+        .unwrap();
+    let owner = Principal::from_text(&owner).map_err(|e| format!("bad owner {}: {}", owner, e))?;
+    Ok((plain_spec, owner))
+}
+
+fn verify_spec_and_get_group_name(
+    spec: &CredentialSpec,
+) -> Result<(CredentialSpec, Principal), String> {
+    let (plain_spec, owner) = get_owner_from_spec(spec)?;
+    match spec.credential_type.as_str() {
+        "VerifiedResidence" => {
+            check_arg_number(1, &plain_spec)?;
+            let _country_name = get_string_arg_value("countryName", &plain_spec)?;
+        }
+        "VerifiedAge" => {
+            check_arg_number(1, &plain_spec)?;
+            let _age_at_least = get_int_arg_value("ageAtLeast", &plain_spec)?;
+        }
+        "VerifiedEmployment" => {
+            check_arg_number(1, &plain_spec)?;
+            let _employer_name = get_string_arg_value("employerName", &plain_spec)?;
+        }
+        "VerifiedHumanity" => {
+            check_arg_number(0, &plain_spec)?;
+        }
+        _ => {
+            return Err(format!(
+                "Credential {} is not supported",
+                spec.credential_type.as_str()
+            ))
+        }
+    };
+    Ok((plain_spec, owner))
 }
 
 #[query]
@@ -842,10 +923,7 @@ fn static_headers() -> Vec<(String, String)> {
 
 fn main() {}
 
-fn verified_member_credential(
-    subject_principal: Principal,
-    credential_spec: &CredentialSpec,
-) -> String {
+fn verifiable_credential(subject_principal: Principal, credential_spec: &CredentialSpec) -> String {
     let params = CredentialParams {
         spec: credential_spec.clone(),
         subject_id: did_for_principal(subject_principal),
@@ -876,23 +954,28 @@ fn prepare_credential_jwt(
     credential_spec: &CredentialSpec,
     alias_tuple: &AliasTuple,
 ) -> Result<String, IssueCredentialError> {
-    let (group_name, owner) = verify_spec_and_get_group_name(credential_spec)
+    let (plain_spec, owner) = verify_spec_and_get_group_name(credential_spec)
         .map_err(IssueCredentialError::UnsupportedCredentialSpec)?;
     GROUPS.with_borrow(|groups| {
-        verify_principal_is_member(alias_tuple.id_dapp, group_name, owner, groups)
+        verify_principal_owns_credential(alias_tuple.id_dapp, &plain_spec, owner, groups)
     })?;
-    Ok(verified_member_credential(
-        alias_tuple.id_alias,
-        credential_spec,
-    ))
+    Ok(verifiable_credential(alias_tuple.id_alias, &plain_spec))
 }
 
-fn verify_principal_is_member(
+fn group_name(credential_type: &str) -> Result<String, IssueCredentialError> {
+    let name = GROUP_NAME_FOR_CREDENTIAL_TYPE.get(credential_type).ok_or(
+        IssueCredentialError::UnsupportedCredentialSpec(credential_type.to_string()),
+    )?;
+    Ok(name.clone())
+}
+
+fn verify_principal_owns_credential(
     user: Principal,
-    group_name: String,
+    credential_spec: &CredentialSpec,
     owner: Principal,
     groups: &GroupsMap,
 ) -> Result<(), IssueCredentialError> {
+    let group_name = group_name(&credential_spec.credential_type)?;
     if let Some(group_record) = groups.get(&(group_name.clone(), owner).into()) {
         if let Some(member_record) = group_record.members.get(&user) {
             if member_record.membership_status == MembershipStatus::Accepted {
@@ -901,8 +984,8 @@ fn verify_principal_is_member(
         }
     }
     Err(IssueCredentialError::UnauthorizedSubject(format!(
-        "user {} is not a member of group [{}]",
-        user, group_name
+        "user {} has no credential [{}] from issuer {}",
+        user, credential_spec.credential_type, owner
     )))
 }
 

--- a/issuer/tests/issue_credentials.rs
+++ b/issuer/tests/issue_credentials.rs
@@ -358,6 +358,7 @@ fn should_fail_prepare_credential_for_wrong_idp_canister_id() {
 }
 fn group_name_for_credential_type(credential_type: &str) -> String {
     match credential_type {
+        "VerifiedMember" => "Verified Member".to_string(),
         "VerifiedResidence" => "Verified Residence".to_string(),
         "VerifiedAge" => "Verified Age".to_string(),
         "VerifiedEmployment" => "Verified Employment".to_string(),
@@ -397,6 +398,32 @@ fn should_prepare_verfied_member_credential_for_authorized_principal() {
         .expect("API call failed");
         assert_matches!(response, Ok(_));
     }
+}
+
+#[test]
+fn should_prepare_verfied_member_credential_for_authorized_principal_legacy_test() {
+    let env = env();
+    let issuer_id = install_issuer(&env, Some(DUMMY_ISSUER_INIT.clone()));
+    let authorized_principal = Principal::from_text(DUMMY_ALIAS_ID_DAPP_PRINCIPAL).unwrap();
+    let owner = principal_1();
+    add_group_with_member(
+        DUMMY_GROUP_NAME,
+        owner,
+        authorized_principal,
+        &env,
+        issuer_id,
+    );
+    let response = api::prepare_credential(
+        &env,
+        issuer_id,
+        authorized_principal,
+        &PrepareCredentialRequest {
+            credential_spec: verified_member_credential_spec(DUMMY_GROUP_NAME, owner),
+            signed_id_alias: DUMMY_SIGNED_ID_ALIAS.clone(),
+        },
+    )
+    .expect("API call failed");
+    assert_matches!(response, Ok(_));
 }
 
 fn rp_add_exclusive_content(
@@ -588,5 +615,172 @@ fn should_issue_share_and_validate_e2e() -> Result<(), CallError> {
         let result = rp_validate_ii_vp(&env, rp_id, principal_1(), validate_vp_request)?;
         assert!(result.is_ok(), "{:?}", result);
     }
+    Ok(())
+}
+
+#[test]
+fn should_issue_share_and_validate_e2e_legacy_test() -> Result<(), CallError> {
+    let env = env();
+    let ii_url = FrontendHostname::from(vc_util::II_ISSUER_URL);
+    let issuer_url = FrontendHostname::from("https://metaissuer.vc/");
+    let rp_url = FrontendHostname::from("https://some-dapp.com/");
+
+    // Setup canisters
+    let ii_id = install_canister::<IssuerInit>(&env, II_WASM.clone(), None);
+    let issuer_id = install_issuer(
+        &env,
+        Some(IssuerInit {
+            ic_root_key_der: env.root_key().to_vec(),
+            idp_canister_ids: vec![ii_id],
+            ..DUMMY_ISSUER_INIT.clone()
+        }),
+    );
+    let rp_id = install_canister(
+        &env,
+        RELYING_PARTY_WASM.clone(),
+        Some(rp_api::RpInit {
+            ic_root_key_der: env.root_key().to_vec(),
+            ii_vc_url: ii_url.clone(),
+            ii_canister_id: ii_id,
+            issuers: vec![IssuerData {
+                vc_url: issuer_url.clone(),
+                canister_id: issuer_id,
+            }],
+        }),
+    );
+
+    // Register a user with II
+    let identity_number = flows::register_anchor(&env, ii_id);
+
+    let prepare_id_alias_req = PrepareIdAliasRequest {
+        identity_number,
+        relying_party: rp_url.clone(),
+        issuer: issuer_url.clone(),
+    };
+
+    let prepared_id_alias =
+        ii_api::prepare_id_alias(&env, ii_id, principal_1(), prepare_id_alias_req)?
+            .expect("prepare id_alias failed");
+
+    let canister_sig_pk =
+        CanisterSigPublicKey::try_from(prepared_id_alias.canister_sig_pk_der.as_ref())
+            .expect("failed parsing canister sig pk");
+
+    let get_id_alias_req = GetIdAliasRequest {
+        identity_number,
+        relying_party: rp_url,
+        issuer: issuer_url.clone(),
+        rp_id_alias_jwt: prepared_id_alias.rp_id_alias_jwt,
+        issuer_id_alias_jwt: prepared_id_alias.issuer_id_alias_jwt,
+    };
+    let id_alias_credentials = ii_api::get_id_alias(&env, ii_id, principal_1(), get_id_alias_req)?
+        .expect("get id_alias failed");
+
+    let root_pk_raw =
+        extract_raw_root_pk_from_der(&env.root_key()).expect("Failed decoding IC root key.");
+    let alias_tuple = get_verified_id_alias_from_jws(
+        &id_alias_credentials
+            .issuer_id_alias_credential
+            .credential_jws,
+        &id_alias_credentials.issuer_id_alias_credential.id_dapp,
+        &canister_sig_pk.canister_id,
+        &root_pk_raw,
+        env.time().duration_since(UNIX_EPOCH).unwrap().as_nanos(),
+    )
+    .expect("Invalid ID alias");
+
+    // Add a group to the meta issuer with the expected member.
+    let authorized_principal = alias_tuple.id_dapp;
+    let owner = principal_1();
+    add_group_with_member(
+        DUMMY_GROUP_NAME,
+        owner,
+        authorized_principal,
+        &env,
+        issuer_id,
+    );
+
+    let credential_spec = verified_member_credential_spec(DUMMY_GROUP_NAME, owner);
+
+    // Add an exclusive content to the rp, gated by a VC.
+    let content_url = "http://example.com";
+
+    rp_add_exclusive_content(
+        &env,
+        rp_id,
+        principal_1(),
+        AddExclusiveContentRequest {
+            content_name: "restricted content".to_string(),
+            url: content_url.to_string(),
+            credential_issuer: owner,
+            credential_spec: CredentialSpec {
+                credential_type: "VerifiedData".to_string(),
+                arguments: None,
+            },
+        },
+    )
+    .expect("API call failed")
+    .expect("Failed add_exclusive_content");
+
+    // Request the credential.
+    let prepared_credential = api::prepare_credential(
+        &env,
+        issuer_id,
+        alias_tuple.id_dapp,
+        &PrepareCredentialRequest {
+            credential_spec: credential_spec.clone(),
+            signed_id_alias: SignedIssuerIdAlias {
+                credential_jws: id_alias_credentials
+                    .issuer_id_alias_credential
+                    .credential_jws
+                    .clone(),
+            },
+        },
+    )?
+    .expect("failed to prepare credential");
+
+    let get_credential_response = api::get_credential(
+        &env,
+        issuer_id,
+        alias_tuple.id_dapp,
+        &GetCredentialRequest {
+            credential_spec: credential_spec.clone(),
+            signed_id_alias: SignedIssuerIdAlias {
+                credential_jws: id_alias_credentials
+                    .issuer_id_alias_credential
+                    .credential_jws
+                    .clone(),
+            },
+            prepared_context: prepared_credential.prepared_context,
+        },
+    )?;
+    let requested_vc_jws = get_credential_response
+        .expect("failed get_credential")
+        .vc_jws;
+    let claims = verify_credential_jws_with_canister_id(
+        &requested_vc_jws,
+        &issuer_id,
+        &root_pk_raw,
+        env.time().duration_since(UNIX_EPOCH).unwrap().as_nanos(),
+    )
+    .expect("credential verification failed");
+    let vc_claims = claims.vc().expect("missing VC claims");
+    validate_claims_match_spec(vc_claims, &credential_spec).expect("Clam validation failed");
+    // Request credential validation from RP's backend.
+    let vp_jwt = build_ii_verifiable_presentation_jwt(
+        id_alias_credentials.rp_id_alias_credential.id_dapp,
+        id_alias_credentials.rp_id_alias_credential.credential_jws,
+        requested_vc_jws,
+    )
+    .expect("failed building VP");
+    let validate_vp_request = ValidateVpRequest {
+        vp_jwt,
+        effective_vc_subject: id_alias_credentials.rp_id_alias_credential.id_dapp,
+        credential_spec,
+        issuer_origin: issuer_url.to_string(),
+        issuer_canister_id: Some(issuer_id),
+    };
+    let result = rp_validate_ii_vp(&env, rp_id, principal_1(), validate_vp_request)?;
+    assert!(result.is_ok(), "{:?}", result);
     Ok(())
 }

--- a/issuer/tests/manage_groups.rs
+++ b/issuer/tests/manage_groups.rs
@@ -23,7 +23,7 @@ fn should_return_group_types() {
     let caller = principal_1();
 
     let group_types = do_group_types(caller, &env, canister_id);
-    assert_eq!(group_types.types.len(), 4);
+    assert_eq!(group_types.types.len(), 5);
     assert_eq!(group_types.types[0].group_name, "Verified Residence");
     assert_eq!(
         group_types.types[0].credential_spec.credential_type,
@@ -43,6 +43,11 @@ fn should_return_group_types() {
     assert_eq!(
         group_types.types[3].credential_spec.credential_type,
         "VerifiedHumanity"
+    );
+    assert_eq!(group_types.types[4].group_name, "Verified Member");
+    assert_eq!(
+        group_types.types[4].credential_spec.credential_type,
+        "VerifiedMember"
     );
 }
 


### PR DESCRIPTION
Change the issuer so that it issues VCs that instead of `VerifiedMember` VCs, it issues VCs of various types supported,
as indicated by `GroupTypes` and by the corresponding spec from a VC request.

*NOTE*: there is no checking of spec arguments yet, this will be added in a follow-up PR.