### PR TITLE
Fix ImageItem title misalignment

### DIFF
--- a/rp/frontend/src/lib/components/ImageItem.svelte
+++ b/rp/frontend/src/lib/components/ImageItem.svelte
@@ -25,9 +25,6 @@
   let groupName: string | undefined;
   $: groupName = $groupNameStore[image.credential_spec.credential_type];
 
-  let title: string;
-  $: title = `${groupName}${credentialPredicate ? ` - ${credentialPredicate}` : ''}`;
-
   const openModal = ({
     content,
     startFlow,
@@ -65,10 +62,10 @@
 
 <article class="card" data-tid="image-item" data-credential-name={groupName}>
   <header class="p-2">
-    <!-- TODO: Fix UI misaligment for titles with multiple lines -->
     <h5 class="h5 w-full">
-      {title}
+      {groupName}
     </h5>
+    <p>{credentialPredicate ?? '-'}</p>
     <p class="text-sm text-surface-600-300-token truncate">
       {`Trusted Issuer: ${image.issuer_nickname}`}
     </p>

--- a/rp/frontend/src/lib/components/ImageItem.svelte
+++ b/rp/frontend/src/lib/components/ImageItem.svelte
@@ -62,10 +62,10 @@
 
 <article class="card" data-tid="image-item" data-credential-name={groupName}>
   <header class="p-2">
-    <h5 class="h5 w-full">
+    <h5 class="h5 w-full truncate">
       {groupName}
     </h5>
-    <p>{credentialPredicate ?? '-'}</p>
+    <p class="truncate">{credentialPredicate ?? '-'}</p>
     <p class="text-sm text-surface-600-300-token truncate">
       {`Trusted Issuer: ${image.issuer_nickname}`}
     </p>


### PR DESCRIPTION
There was a UI issue when a title covered two lines and another one only one line.

In this PR, I change the title to only the group name and render the predicate as a subtitle. Ensuring always the same amount of lines and alignment between items.