### PR TITLE
Fix requesting verified age

### DIFF
--- a/issuer/frontend/src/lib/components/MemberIssuerItem.svelte
+++ b/issuer/frontend/src/lib/components/MemberIssuerItem.svelte
@@ -134,8 +134,8 @@
           required: true,
           placeholder: placeholderMapper[issuer.group_name],
         },
-        response: async (userInput: string | false) => {
-          if (typeof userInput === 'string') {
+        response: async (userInput: string | number | false) => {
+          if (typeof userInput === 'string' || typeof userInput === 'number') {
             await requestCredential({
               identity: $authStore.identity,
               issuerName: issuer.group_name,

--- a/issuer/frontend/src/lib/services/request-credential.services.ts
+++ b/issuer/frontend/src/lib/services/request-credential.services.ts
@@ -21,7 +21,7 @@ export const requestCredential = async ({
   issuerName: string;
   owner: Principal;
   toastStore: ToastStore;
-  credentialArgument?: string;
+  credentialArgument?: string | number;
   credentialSpec?: CredentialSpec;
 }) => {
   try {


### PR DESCRIPTION
There was a bug when the user requested a verifiedAge credential.

The problem was that the library returned a number if the input is of type number, not a string.