### PR TITLE
Display badges with approved and pending count

### DIFF
--- a/issuer/frontend/src/lib/components/IssuerItem.svelte
+++ b/issuer/frontend/src/lib/components/IssuerItem.svelte
@@ -2,10 +2,13 @@
   import ListItem from '$lib/ui-components/elements/ListItem.svelte';
   import { vcArgumentsValue } from '$lib/utils/vc-arguments-value.utils';
   import type { PublicGroupData } from '../../declarations/meta_issuer.did';
-  import Badge from "$lib/ui-components/elements/Badge.svelte";
-  import {countApprovedCredentials, countPendingCredentials} from "$lib/utils/count-approved-credentials.utils";
-  import {getIssuerDetailStore, type IssuerDetailStore} from "$lib/stores/issuer-detail.store";
-  import {authStore} from "$lib/stores/auth.store";
+  import Badge from '$lib/ui-components/elements/Badge.svelte';
+  import {
+    countApprovedCredentials,
+    countPendingCredentials,
+  } from '$lib/utils/count-approved-credentials.utils';
+  import { getIssuerDetailStore, type IssuerDetailStore } from '$lib/stores/issuer-detail.store';
+  import { authStore } from '$lib/stores/auth.store';
 
   export let issuer: PublicGroupData;
   export let onClick: (() => void) | undefined = undefined;
@@ -33,10 +36,12 @@
     {#if vcArgumentValue !== undefined}
       {` - ${vcArgumentValue}`}
     {/if}
-    <p>
-      <Badge variant="success">Approved: {approvedCredentials}</Badge>
-      <Badge variant="default">Pending: {pendingCredentials}</Badge>
-    </p>
+    {#if isAdmin}
+      <div>
+        <Badge variant="success">Approved: {approvedCredentials}</Badge>
+        <Badge variant="default">Pending: {pendingCredentials}</Badge>
+      </div>
+    {/if}
   </svelte:fragment>
   <span slot="sub">{`Issued by ${issuer.issuer_nickname}`}</span>
   <slot name="end" slot="end" />

--- a/issuer/frontend/src/lib/components/IssuerItem.svelte
+++ b/issuer/frontend/src/lib/components/IssuerItem.svelte
@@ -38,8 +38,8 @@
     {/if}
     {#if isAdmin}
       <div>
-        <Badge variant="success">Approved: {approvedCredentials}</Badge>
-        <Badge variant="default">Pending: {pendingCredentials}</Badge>
+        <Badge variant="success">{`🪪 Approved: ${approvedCredentials}`}</Badge>
+        <Badge variant="default">{`📤 Pending: ${pendingCredentials}`}</Badge>
       </div>
     {/if}
   </svelte:fragment>

--- a/issuer/frontend/src/lib/components/IssuerItem.svelte
+++ b/issuer/frontend/src/lib/components/IssuerItem.svelte
@@ -2,6 +2,10 @@
   import ListItem from '$lib/ui-components/elements/ListItem.svelte';
   import { vcArgumentsValue } from '$lib/utils/vc-arguments-value.utils';
   import type { PublicGroupData } from '../../declarations/meta_issuer.did';
+  import Badge from "$lib/ui-components/elements/Badge.svelte";
+  import {countApprovedCredentials, countPendingCredentials} from "$lib/utils/count-approved-credentials.utils";
+  import {getIssuerDetailStore, type IssuerDetailStore} from "$lib/stores/issuer-detail.store";
+  import {authStore} from "$lib/stores/auth.store";
 
   export let issuer: PublicGroupData;
   export let onClick: (() => void) | undefined = undefined;
@@ -11,6 +15,16 @@
   // This might happen because admins can request credentials to themselves.
   let vcArgumentValue: string | number | undefined;
   $: vcArgumentValue = isAdmin ? undefined : vcArgumentsValue(issuer.vc_arguments);
+
+  let issuerStore: IssuerDetailStore;
+  $: issuerStore = getIssuerDetailStore({
+    identity: $authStore.identity,
+    issuerName: issuer.group_name ?? '',
+  });
+  let approvedCredentials: number;
+  $: approvedCredentials = countApprovedCredentials($issuerStore?.members ?? []);
+  let pendingCredentials: number;
+  $: pendingCredentials = countPendingCredentials($issuerStore?.members ?? []);
 </script>
 
 <ListItem testId={`credentials ${issuer.issuer_nickname} ${issuer.group_name}`} {onClick}>
@@ -19,6 +33,10 @@
     {#if vcArgumentValue !== undefined}
       {` - ${vcArgumentValue}`}
     {/if}
+    <p>
+      <Badge variant="success">Approved: {approvedCredentials}</Badge>
+      <Badge variant="default">Pending: {pendingCredentials}</Badge>
+    </p>
   </svelte:fragment>
   <span slot="sub">{`Issued by ${issuer.issuer_nickname}`}</span>
   <slot name="end" slot="end" />


### PR DESCRIPTION
On the issuer control center overview badges are added that show the number of pending and approved credentials.
<img width="733" alt="Screenshot 2024-06-17 at 11 37 05" src="https://github.com/dfinity/vc-playground/assets/94825501/cbaf0a97-3ed0-41ad-be59-4eba73affa9a">
